### PR TITLE
Update to 1.18 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,14 +58,14 @@
         <!-- Non-minecraft related dependencies -->
         <powermock.version>2.0.9</powermock.version>
         <!-- More visible way how to change dependency versions -->
-        <spigot.version>1.17-R0.1-SNAPSHOT</spigot.version>
-        <bentobox.version>1.18.0</bentobox.version>
+        <spigot.version>1.18-R0.1-SNAPSHOT</spigot.version>
+        <bentobox.version>1.20.0</bentobox.version>
         <!-- Revision variable removes warning about dynamic version -->
         <revision>${build.version}-SNAPSHOT</revision>
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>1.15.2</build.version>
+        <build.version>1.16.0</build.version>
         <!-- Sonar Cloud -->
         <sonar.projectKey>BentoBoxWorld_AcidIsland</sonar.projectKey>
         <sonar.organization>bentobox-world</sonar.organization>

--- a/src/main/java/world/bentobox/acidisland/world/ChunkGeneratorWorld.java
+++ b/src/main/java/world/bentobox/acidisland/world/ChunkGeneratorWorld.java
@@ -44,9 +44,9 @@ public class ChunkGeneratorWorld extends ChunkGenerator {
 
     public ChunkData generateChunks(World world) {
         ChunkData result = createChunkData(world);
-        int sh = seaHeight.getOrDefault(world.getEnvironment(), 0);
-        if (sh > 0) {
-            result.setRegion(0, 0, 0, 16, sh + 1, 16, Material.WATER);
+        int sh = seaHeight.getOrDefault(world.getEnvironment(), world.getMinHeight());
+        if (sh > world.getMinHeight()) {
+            result.setRegion(0, world.getMinHeight(), 0, 16, sh + 1, 16, Material.WATER);
         }
         if (world.getEnvironment().equals(Environment.NETHER) && addon.getSettings().isNetherRoof()) {
             roofChunk.forEach((k,v) -> result.setBlock(k.getBlockX(), world.getMaxHeight() + k.getBlockY(), k.getBlockZ(), v));
@@ -65,7 +65,7 @@ public class ChunkGeneratorWorld extends ChunkGenerator {
             world.getEnvironment() == Environment.NETHER ? addon.getSettings().getDefaultNetherBiome() : addon.getSettings().getDefaultEndBiome();
             for (int x = 0; x < 16; x+=4) {
                 for (int z = 0; z < 16; z+=4) {
-                    for (int y = 0; y < world.getMaxHeight(); y+=4) {
+                    for (int y = world.getMinHeight(); y < world.getMaxHeight(); y+=4) {
                         biomeGrid.setBiome(x, y, z, biome);
                     }
                 }


### PR DESCRIPTION
- Update to Spigot 1.18 and BentoBox 1.20.
- Fix an issue when the world was not generated from minHeight.
