### PR TITLE
Prepare 1.22.0: purified water polish, locale sync, dimension toggles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>1.21.0</build.version>
+        <build.version>1.22.0</build.version>
         <!-- Sonar Cloud -->
         <sonar.projectKey>BentoBoxWorld_AcidIsland</sonar.projectKey>
         <sonar.organization>bentobox-world</sonar.organization>

--- a/src/main/java/world/bentobox/acidisland/AISettings.java
+++ b/src/main/java/world/bentobox/acidisland/AISettings.java
@@ -149,10 +149,6 @@ public class AISettings implements WorldSettings {
     @ConfigEntry(path = "acid.purified-water.enabled", since = "1.21")
     private boolean purifiedWaterEnabled = true;
 
-    @ConfigComment("Damage dealt to a player who drinks an acid water bottle (in half-hearts)")
-    @ConfigEntry(path = "acid.purified-water.drink-damage", since = "1.21")
-    private double acidDrinkDamage = 4.0;
-
     @ConfigComment("Health restored to a player who drinks a purified water bottle (in half-hearts)")
     @ConfigEntry(path = "acid.purified-water.heal-amount", since = "1.21")
     private double purifiedWaterHeal = 4.0;
@@ -162,6 +158,14 @@ public class AISettings implements WorldSettings {
     @ConfigComment("Disable if this feels too easy for your server's balance.")
     @ConfigEntry(path = "acid.purified-water.bucket-furnace-enabled", since = "1.21")
     private boolean purifiedBucketFurnaceEnabled = true;
+
+    @ConfigComment("Run the purified water mechanic in the addon's Nether world (island or vanilla).")
+    @ConfigEntry(path = "acid.purified-water.nether-enabled", since = "1.22")
+    private boolean purifiedWaterNetherEnabled = true;
+
+    @ConfigComment("Run the purified water mechanic in the addon's End world (island or vanilla).")
+    @ConfigEntry(path = "acid.purified-water.end-enabled", since = "1.22")
+    private boolean purifiedWaterEndEnabled = true;
 
 
     /*      WORLD       */
@@ -694,12 +698,6 @@ public class AISettings implements WorldSettings {
         return acidDestroyItemTime;
     }
     /**
-     * @return damage dealt when drinking an acid water bottle (half-hearts)
-     */
-    public double getAcidDrinkDamage() {
-        return acidDrinkDamage;
-    }
-    /**
      * @return the acidEffects
      */
     public List<PotionEffectType> getAcidEffects() {
@@ -728,6 +726,18 @@ public class AISettings implements WorldSettings {
      */
     public boolean isPurifiedBucketFurnaceEnabled() {
         return purifiedBucketFurnaceEnabled;
+    }
+    /**
+     * @return true if the purified water mechanic runs in the island Nether
+     */
+    public boolean isPurifiedWaterNetherEnabled() {
+        return purifiedWaterNetherEnabled;
+    }
+    /**
+     * @return true if the purified water mechanic runs in the island End
+     */
+    public boolean isPurifiedWaterEndEnabled() {
+        return purifiedWaterEndEnabled;
     }
 
     @Override
@@ -1207,12 +1217,6 @@ public class AISettings implements WorldSettings {
         this.acidDamage = acidDamage;
     }
     /**
-     * @param acidDrinkDamage damage dealt when drinking an acid water bottle (half-hearts)
-     */
-    public void setAcidDrinkDamage(double acidDrinkDamage) {
-        this.acidDrinkDamage = acidDrinkDamage;
-    }
-    /**
      * @param purifiedWaterEnabled true to enable the purified water mechanic
      */
     public void setPurifiedWaterEnabled(boolean purifiedWaterEnabled) {
@@ -1229,6 +1233,18 @@ public class AISettings implements WorldSettings {
      */
     public void setPurifiedBucketFurnaceEnabled(boolean purifiedBucketFurnaceEnabled) {
         this.purifiedBucketFurnaceEnabled = purifiedBucketFurnaceEnabled;
+    }
+    /**
+     * @param purifiedWaterNetherEnabled true to run the mechanic in the island Nether
+     */
+    public void setPurifiedWaterNetherEnabled(boolean purifiedWaterNetherEnabled) {
+        this.purifiedWaterNetherEnabled = purifiedWaterNetherEnabled;
+    }
+    /**
+     * @param purifiedWaterEndEnabled true to run the mechanic in the island End
+     */
+    public void setPurifiedWaterEndEnabled(boolean purifiedWaterEndEnabled) {
+        this.purifiedWaterEndEnabled = purifiedWaterEndEnabled;
     }
     /**
      * @param acidDamageAnimal the acidDamageAnimal to set

--- a/src/main/java/world/bentobox/acidisland/listeners/PurifiedWaterListener.java
+++ b/src/main/java/world/bentobox/acidisland/listeners/PurifiedWaterListener.java
@@ -46,6 +46,7 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionType;
 
+import world.bentobox.acidisland.AISettings;
 import world.bentobox.acidisland.AcidIsland;
 import world.bentobox.acidisland.events.ItemFillWithAcidEvent;
 import world.bentobox.acidisland.events.PlayerDrinkPurifiedWaterEvent;
@@ -226,7 +227,7 @@ public class PurifiedWaterListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onCauldronChange(CauldronLevelChangeEvent e) {
         if (!addon.getSettings().isPurifiedWaterEnabled()) return;
-        if (!e.getBlock().getWorld().equals(addon.getOverWorld())) return;
+        if (!isAcidIslandWorld(e.getBlock().getWorld())) return;
 
         Location loc = e.getBlock().getLocation();
         ChangeReason reason = e.getReason();
@@ -276,7 +277,7 @@ public class PurifiedWaterListener implements Listener {
         if (!addon.getSettings().isPurifiedWaterEnabled()) return;
 
         Player player = e.getPlayer();
-        if (!player.getWorld().equals(addon.getOverWorld())) return;
+        if (!isAcidIslandWorld(player.getWorld())) return;
 
         ItemStack item = e.getItem();
         if (item == null || item.getType() != Material.GLASS_BOTTLE) return;
@@ -337,7 +338,7 @@ public class PurifiedWaterListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onBucketFill(PlayerBucketFillEvent e) {
         if (!addon.getSettings().isPurifiedWaterEnabled()) return;
-        if (!e.getPlayer().getWorld().equals(addon.getOverWorld())) return;
+        if (!isAcidIslandWorld(e.getPlayer().getWorld())) return;
 
         ItemStack result = e.getItemStack();
         if (result == null || result.getType() != Material.WATER_BUCKET) return;
@@ -449,6 +450,25 @@ public class PurifiedWaterListener implements Listener {
 
     private Optional<Island> getIsland(Player player) {
         return addon.getIslands().getIslandAt(player.getLocation());
+    }
+
+    /**
+     * @return {@code true} if the purified water mechanic should operate in the given world.
+     * The mechanic always runs in the AcidIsland overworld. It also runs in the addon's Nether
+     * and End worlds (whether they are island or vanilla) when the per-dimension config toggle
+     * is enabled.
+     */
+    private boolean isAcidIslandWorld(World world) {
+        if (world == null) return false;
+        if (world.equals(addon.getOverWorld())) return true;
+        AISettings s = addon.getSettings();
+        if (world.equals(addon.getNetherWorld()) && s.isPurifiedWaterNetherEnabled()) {
+            return true;
+        }
+        if (world.equals(addon.getEndWorld()) && s.isPurifiedWaterEndEnabled()) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -78,14 +78,16 @@ acid:
   purified-water:
     # Enable or disable the entire purified water mechanic.
     enabled: true
-    # Damage (in half-hearts) dealt to a player who drinks an acid water bottle.
-    drink-damage: 4.0
     # Health (in half-hearts) restored to a player who drinks a purified water bottle.
     heal-amount: 4.0
     # Allow purifying a water bucket by smelting it in a furnace.
     # Cook time is 2000 ticks (100 seconds) to balance the effort.
     # Disable if this feels too easy for your server's balance.
     bucket-furnace-enabled: true
+    # Run the purified water mechanic in the addon's Nether world (island or vanilla).
+    nether-enabled: true
+    # Run the purified water mechanic in the addon's End world (island or vanilla).
+    end-enabled: true
 world:
   # Friendly name for this world. Used in admin commands. Must be a single word
   # /!\ BentoBox currently does not support changing this value mid-game. If you do need to change it, do a full reset of your databases and worlds.

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -12,3 +12,6 @@ acidisland:
     line2: "Voda je kyselina!"
     line3: "Buď opatrný! <red><3"
     
+  purified-water:
+    lore-acid: "<red>Kyselá voda"
+    lore-purified: "<green>Čistá voda"

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -5,3 +5,6 @@ acidisland:
     line1: "[name]"
     line2: Achtung! Das Wasser
     line3: "ist vergiftet! <red><3"
+  purified-water:
+    lore-acid: "<red>Säurewasser"
+    lore-purified: "<green>Gereinigtes Wasser"

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -9,3 +9,6 @@ acidisland:
     line1: "[name]"
     line2: "El Agua es acida!"
     line3: "Ten cuidado! <red><3"
+  purified-water:
+    lore-acid: "<red>Agua ácida"
+    lore-purified: "<green>Agua purificada"

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -5,3 +5,6 @@ acidisland:
     line1: "[name]"
     line2: L'eau est acide!
     line3: "Faites attention! <red><3"
+  purified-water:
+    lore-acid: "<red>Eau acide"
+    lore-purified: "<green>Eau purifiée"

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -5,3 +5,6 @@ acidisland:
     line1: "[name]"
     line2: Voda je kiselina!
     line3: "Budi oprezan! <red><3"
+  purified-water:
+    lore-acid: "<red>Kisela voda"
+    lore-purified: "<green>Pročišćena voda"

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -10,3 +10,6 @@ acidisland:
     line2: "A víz savas!"
     line3: "Légy óvatos! <red><3"
     
+  purified-water:
+    lore-acid: "<red>Savas víz"
+    lore-purified: "<green>Tisztított víz"

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -6,3 +6,6 @@ acidisland:
     line2: Airnya Asam!
     line3: "Hati-hati! <red><3"
 
+  purified-water:
+    lore-acid: "<red>Air asam"
+    lore-purified: "<green>Air murni"

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -9,3 +9,6 @@ acidisland:
     line1: "[name]"
     line2: "L''acqua è acida!"
     line3: "Stai attento! <red><3"
+  purified-water:
+    lore-acid: "<red>Acqua acida"
+    lore-purified: "<green>Acqua purificata"

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -5,3 +5,6 @@ acidisland:
     line1: "[name]"
     line2: 水は酸性です！
     line3: "注意してください！ <red><3"
+  purified-water:
+    lore-acid: "<red>酸性の水"
+    lore-purified: "<green>浄化された水"

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -5,3 +5,6 @@ acidisland:
     line1: "[name]"
     line2: 물은 산성 입니다!
     line3: "조심하세요! <red><3"
+  purified-water:
+    lore-acid: "<red>산성 물"
+    lore-purified: "<green>정화된 물"

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -5,3 +5,6 @@ acidisland:
     line1: "[name]"
     line2: Ūdens satur skābi!
     line3: "Esi uzmanīgs! <red><3"
+  purified-water:
+    lore-acid: "<red>Skābes ūdens"
+    lore-purified: "<green>Attīrīts ūdens"

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -5,3 +5,6 @@ acidisland:
     line1: "[name]"
     line2: Woda jest kwaśna!
     line3: "Bądź ostrożny! <red><3"
+  purified-water:
+    lore-acid: "<red>Kwaśna woda"
+    lore-purified: "<green>Oczyszczona woda"

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -6,3 +6,6 @@ acidisland:
     line2: Apa este acida!
     line3: "Ai grija! <red><3"
 
+  purified-water:
+    lore-acid: "<red>Apă acidă"
+    lore-purified: "<green>Apă purificată"

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -5,3 +5,6 @@ acidisland:
     line1: "[name]"
     line2: Выживание в море!
     line3: "Удачной игры! <red><3"
+  purified-water:
+    lore-acid: "<red>Кислотная вода"
+    lore-purified: "<green>Очищенная вода"

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -5,3 +5,6 @@ acidisland:
     line1: "[name]"
     line2: Su asitli!
     line3: "Dikkat et! <red><3"
+  purified-water:
+    lore-acid: "<red>Asitli Su"
+    lore-purified: "<green>Arıtılmış Su"

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -5,3 +5,6 @@ acidisland:
     line1: "[name]"
     line2: Вода кислотна!
     line3: "Будь обережний! <red><3"
+  purified-water:
+    lore-acid: "<red>Кислотна вода"
+    lore-purified: "<green>Очищена вода"

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -5,3 +5,6 @@ acidisland:
     line1: "[name]"
     line2: Nước là axit!
     line3: "Hãy cẩn thận! <red><3"
+  purified-water:
+    lore-acid: "<red>Nước axit"
+    lore-purified: "<green>Nước tinh khiết"

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -10,3 +10,6 @@ acidisland:
     line2: "水是酸的！"
     line3: "要小心哟！<red><3"
     
+  purified-water:
+    lore-acid: "<red>酸水"
+    lore-purified: "<green>纯净水"

--- a/src/test/java/world/bentobox/acidisland/listeners/PurifiedWaterListenerTest.java
+++ b/src/test/java/world/bentobox/acidisland/listeners/PurifiedWaterListenerTest.java
@@ -122,7 +122,6 @@ class PurifiedWaterListenerTest {
 
         when(settings.isPurifiedWaterEnabled()).thenReturn(true);
         when(settings.isPurifiedBucketFurnaceEnabled()).thenReturn(true);
-        when(settings.getAcidDrinkDamage()).thenReturn(4.0);
         when(settings.getPurifiedWaterHeal()).thenReturn(4.0);
 
         when(player.getWorld()).thenReturn(world);


### PR DESCRIPTION
- Bump build.version to 1.22.0.
- Remove unused acid.purified-water.drink-damage config (acid bottles use vanilla Poison).
- Add acid.purified-water.nether-enabled / end-enabled toggles; mechanic now runs in the addon's nether/end (island or vanilla) when enabled.
- Sync new purified-water lore keys into all 18 translated locales.