### PR TITLE
Release 2.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@ca2dcd167e8db4e0f671a976080744dda43801a6 # master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@83854779c88155085dca4b06bff7f133da6b8923 # fix/curl-form-inline-parsing
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
       hangar_slug: "AcidIsland"           # blank = skip Hangar

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>2.0.0</build.version>
+        <build.version>2.1.0</build.version>
         <!-- Sonar Cloud -->
         <sonar.projectKey>BentoBoxWorld_AcidIsland</sonar.projectKey>
         <sonar.organization>bentobox-world</sonar.organization>

--- a/src/main/java/world/bentobox/acidisland/AISettings.java
+++ b/src/main/java/world/bentobox/acidisland/AISettings.java
@@ -274,6 +274,8 @@ public class AISettings implements WorldSettings {
     @ConfigComment("Items thrown into the water around a sulfur vent are consumed as offerings and")
     @ConfigComment("transmuted into rewards that are spewed out when the vent next erupts as a geyser.")
     @ConfigComment("Rewards are defined in geyser-loot.yml in the addon's data folder.")
+    @ConfigComment("Works with acid item destruction: items the acid destroys within a vent's pool")
+    @ConfigComment("count as offerings instead of being lost.")
     @ConfigComment("Requires Minecraft 26.2 or later - ignored on older servers.")
     @ConfigEntry(path = "world.geyser-offerings.enabled")
     private boolean geyserOfferings = true;

--- a/src/main/java/world/bentobox/acidisland/AISettings.java
+++ b/src/main/java/world/bentobox/acidisland/AISettings.java
@@ -269,6 +269,18 @@ public class AISettings implements WorldSettings {
     @ConfigEntry(path = "world.sulfur-vent-chance", needsReset = true)
     private int sulfurVentChance = 10;
 
+    @ConfigComment("Geyser offerings")
+    @ConfigComment("Items thrown into the water around a sulfur vent are consumed as offerings and")
+    @ConfigComment("transmuted into rewards that are spewed out when the vent next erupts as a geyser.")
+    @ConfigComment("Rewards are defined in geyser-loot.yml in the addon's data folder.")
+    @ConfigComment("Requires Minecraft 26.2 or later - ignored on older servers.")
+    @ConfigEntry(path = "world.geyser-offerings.enabled")
+    private boolean geyserOfferings = true;
+
+    @ConfigComment("Maximum number of rewards a single eruption can spew, however many items were offered.")
+    @ConfigEntry(path = "world.geyser-offerings.max-rewards")
+    private int geyserMaxRewards = 12;
+
     @ConfigComment("Structures")
     @ConfigComment("This creates an vanilla structures in the worlds.")
     @ConfigComment("Trial chambers and other underground structures generate buried")
@@ -2167,6 +2179,34 @@ public class AISettings implements WorldSettings {
      */
     public void setSulfurVentChance(int sulfurVentChance) {
         this.sulfurVentChance = sulfurVentChance;
+    }
+
+    /**
+     * @return true if sulfur vents accept item offerings and transmute them into rewards
+     */
+    public boolean isGeyserOfferings() {
+        return geyserOfferings;
+    }
+
+    /**
+     * @param geyserOfferings the geyserOfferings to set
+     */
+    public void setGeyserOfferings(boolean geyserOfferings) {
+        this.geyserOfferings = geyserOfferings;
+    }
+
+    /**
+     * @return the maximum number of rewards a single eruption can spew
+     */
+    public int getGeyserMaxRewards() {
+        return geyserMaxRewards;
+    }
+
+    /**
+     * @param geyserMaxRewards the geyserMaxRewards to set
+     */
+    public void setGeyserMaxRewards(int geyserMaxRewards) {
+        this.geyserMaxRewards = geyserMaxRewards;
     }
 
     /**

--- a/src/main/java/world/bentobox/acidisland/AISettings.java
+++ b/src/main/java/world/bentobox/acidisland/AISettings.java
@@ -265,8 +265,9 @@ public class AISettings implements WorldSettings {
     @ConfigComment("Sulfur vents")
     @ConfigComment("Chance (0-100) per chunk of a sulfur vent generating just below the sea surface.")
     @ConfigComment("Vents are made of potent sulfur over a magma block and bubble, gas, and erupt as geysers.")
+    @ConfigComment("Changing this only affects newly generated chunks.")
     @ConfigComment("Requires Minecraft 26.2 or later - ignored on older servers.")
-    @ConfigEntry(path = "world.sulfur-vent-chance", needsReset = true)
+    @ConfigEntry(path = "world.sulfur-vent-chance")
     private int sulfurVentChance = 10;
 
     @ConfigComment("Geyser offerings")

--- a/src/main/java/world/bentobox/acidisland/AcidIsland.java
+++ b/src/main/java/world/bentobox/acidisland/AcidIsland.java
@@ -58,7 +58,10 @@ public class AcidIsland extends GameModeAddon {
         // Save the default config from config.yml
         saveDefaultConfig();
         // Load settings from config.yml. This will check if there are any issues with it too.
-        loadSettings();
+        if (!loadSettings()) {
+            // Settings did not load - the addon has been disabled
+            return;
+        }
         // Make the biome provider
         this.biomeProvider = new AcidBiomeProvider(this);
         // Chunk generator

--- a/src/main/java/world/bentobox/acidisland/AcidIsland.java
+++ b/src/main/java/world/bentobox/acidisland/AcidIsland.java
@@ -14,6 +14,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import world.bentobox.acidisland.commands.IslandAboutCommand;
+import world.bentobox.acidisland.geysers.GeyserOfferingsTask;
 import world.bentobox.acidisland.listeners.AcidEffect;
 import world.bentobox.acidisland.listeners.LavaCheck;
 import world.bentobox.acidisland.listeners.PurifiedWaterListener;
@@ -36,6 +37,7 @@ public class AcidIsland extends GameModeAddon {
 
     private @Nullable AISettings settings;
     private @Nullable AcidTask acidTask;
+    private @Nullable GeyserOfferingsTask geyserOfferingsTask;
     private @Nullable ChunkGenerator chunkGenerator;
     private final Config<AISettings> config = new Config<>(this, AISettings.class);
     private BiomeProvider biomeProvider;
@@ -107,11 +109,14 @@ public class AcidIsland extends GameModeAddon {
         registerListener(new PurifiedWaterListener(this));
         // Burn everything
         acidTask = new AcidTask(this);
+        // Sulfur vents accept offerings and transmute them into geyser rewards
+        geyserOfferingsTask = new GeyserOfferingsTask(this);
     }
 
     @Override
     public void onDisable() {
         if (acidTask != null) acidTask.cancelTasks();
+        if (geyserOfferingsTask != null) geyserOfferingsTask.cancelTasks();
     }
 
     @NonNull

--- a/src/main/java/world/bentobox/acidisland/AcidIsland.java
+++ b/src/main/java/world/bentobox/acidisland/AcidIsland.java
@@ -127,6 +127,14 @@ public class AcidIsland extends GameModeAddon {
         return Objects.requireNonNull(settings);
     }
 
+    /**
+     * @return the geyser offerings task, or null before onEnable
+     */
+    @Nullable
+    public GeyserOfferingsTask getGeyserOfferingsTask() {
+        return geyserOfferingsTask;
+    }
+
     /* (non-Javadoc)
      * @see world.bentobox.bentobox.api.addons.GameModeAddon#createWorlds()
      */

--- a/src/main/java/world/bentobox/acidisland/events/GeyserSacrificeEvent.java
+++ b/src/main/java/world/bentobox/acidisland/events/GeyserSacrificeEvent.java
@@ -1,0 +1,72 @@
+package world.bentobox.acidisland.events;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Item;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Fired when an item thrown into the water above a sulfur vent is about to be
+ * consumed as an offering. Cancelling leaves the item floating in the pool.
+ *
+ * @author tastybento
+ * @since 2.1.0
+ */
+public class GeyserSacrificeEvent extends Event implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private final Item item;
+    private final Location vent;
+    private final @Nullable String channel;
+    private boolean cancelled;
+
+    public GeyserSacrificeEvent(Item item, Location vent, @Nullable String channel) {
+        this.item = item;
+        this.vent = vent;
+        this.channel = channel;
+    }
+
+    /**
+     * @return the item being sacrificed
+     */
+    public Item getItem() {
+        return item;
+    }
+
+    /**
+     * @return the location of the vent's potent sulfur cap
+     */
+    public Location getVent() {
+        return vent;
+    }
+
+    /**
+     * @return the reward channel the offering biases, or null if it burns with no bias
+     */
+    @Nullable
+    public String getChannel() {
+        return channel;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/world/bentobox/acidisland/events/GeyserSacrificeEvent.java
+++ b/src/main/java/world/bentobox/acidisland/events/GeyserSacrificeEvent.java
@@ -8,8 +8,10 @@ import org.bukkit.event.HandlerList;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * Fired when an item thrown into the water above a sulfur vent is about to be
- * consumed as an offering. Cancelling leaves the item floating in the pool.
+ * Fired when an item in the water around a sulfur vent is about to be consumed
+ * as an offering - either by the offerings task or by acid item destruction
+ * dissolving it within the vent's pool. Cancelling leaves the item floating in
+ * the pool (acid destruction then proceeds as normal, if it applies).
  *
  * @author tastybento
  * @since 2.1.0

--- a/src/main/java/world/bentobox/acidisland/events/GeyserTransmuteEvent.java
+++ b/src/main/java/world/bentobox/acidisland/events/GeyserTransmuteEvent.java
@@ -1,0 +1,60 @@
+package world.bentobox.acidisland.events;
+
+import java.util.List;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Item;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Fired after a sulfur vent's eruption has spewed out the rewards transmuted
+ * from the offerings sacrificed to it.
+ *
+ * @author tastybento
+ * @since 2.1.0
+ */
+public class GeyserTransmuteEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private final Location vent;
+    private final List<Item> rewards;
+    private final int offerings;
+
+    public GeyserTransmuteEvent(Location vent, List<Item> rewards, int offerings) {
+        this.vent = vent;
+        this.rewards = rewards;
+        this.offerings = offerings;
+    }
+
+    /**
+     * @return the location of the vent's potent sulfur cap
+     */
+    public Location getVent() {
+        return vent;
+    }
+
+    /**
+     * @return the spawned reward item entities
+     */
+    public List<Item> getRewards() {
+        return rewards;
+    }
+
+    /**
+     * @return the number of items that were sacrificed to this vent
+     */
+    public int getOfferings() {
+        return offerings;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/world/bentobox/acidisland/geysers/GeyserLootEntry.java
+++ b/src/main/java/world/bentobox/acidisland/geysers/GeyserLootEntry.java
@@ -1,0 +1,78 @@
+package world.bentobox.acidisland.geysers;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * One weighted entry in the geyser reward table. Either an item (material +
+ * amount range) or a console command with {@code %player%} substitution.
+ *
+ * @param material the material, or null for command entries
+ * @param command the console command, or null for item entries
+ * @param weight the base weight
+ * @param channel the offering channel this entry belongs to, or null
+ * @param min minimum amount
+ * @param max maximum amount
+ *
+ * @author tastybento
+ * @since 2.1.0
+ */
+public record GeyserLootEntry(@Nullable Material material, @Nullable String command, int weight,
+        @Nullable String channel, int min, int max) {
+
+    /**
+     * @return true if this is a command reward rather than an item
+     */
+    public boolean isCommand() {
+        return command != null;
+    }
+
+    /**
+     * Roll an item stack from this entry.
+     *
+     * @param random random source
+     * @return stack with a random amount in [min, max]
+     */
+    public ItemStack toItemStack(Random random) {
+        int amount = min >= max ? min : min + random.nextInt(max - min + 1);
+        return new ItemStack(material, Math.max(1, amount));
+    }
+
+    /**
+     * Parse an entry from a YAML map, e.g.
+     * {@code {item: RAW_IRON, weight: 30, channel: mineral, amount: {min: 1, max: 3}}}
+     * or {@code {command: "say hi %player%", weight: 1}}.
+     *
+     * @param map the raw map from the YAML list
+     * @return the entry, or null if invalid
+     */
+    @Nullable
+    public static GeyserLootEntry parse(Map<?, ?> map) {
+        int weight = map.get("weight") instanceof Number n ? n.intValue() : 1;
+        String channel = map.get("channel") instanceof String s ? s.toLowerCase(Locale.ROOT) : null;
+        int min = 1;
+        int max = 1;
+        if (map.get("amount") instanceof Map<?, ?> amount) {
+            min = amount.get("min") instanceof Number n ? n.intValue() : 1;
+            max = amount.get("max") instanceof Number n ? n.intValue() : min;
+        } else if (map.get("amount") instanceof Number n) {
+            min = n.intValue();
+            max = n.intValue();
+        }
+        if (map.get("command") instanceof String command && !command.isBlank()) {
+            return new GeyserLootEntry(null, command, weight, channel, min, max);
+        }
+        if (map.get("item") instanceof String item) {
+            Material material = Material.matchMaterial(item);
+            if (material != null) {
+                return new GeyserLootEntry(material, null, weight, channel, min, max);
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/world/bentobox/acidisland/geysers/GeyserLootTable.java
+++ b/src/main/java/world/bentobox/acidisland/geysers/GeyserLootTable.java
@@ -1,0 +1,143 @@
+package world.bentobox.acidisland.geysers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+
+import org.bukkit.Material;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * The weighted geyser reward table, loaded from {@code geyser-loot.yml}.
+ * Entries with a channel are boosted by the offerings sacrificed to the vent:
+ * <pre>
+ * effective = weight × (1 + 0.5 × offeringPoints(entry.channel))
+ * </pre>
+ * so a vent fed diamonds leans towards gems, a vent fed logs towards forestry,
+ * and so on.
+ *
+ * @author tastybento
+ * @since 2.1.0
+ */
+public class GeyserLootTable {
+
+    private final List<GeyserLootEntry> loot;
+
+    public GeyserLootTable(List<GeyserLootEntry> loot) {
+        this.loot = loot;
+    }
+
+    /**
+     * Load a table from YAML: a list of entries under the {@code loot:} key.
+     *
+     * @param config loaded YAML
+     * @return the table; empty if no valid entries were found
+     */
+    @NonNull
+    public static GeyserLootTable parse(YamlConfiguration config) {
+        List<GeyserLootEntry> loot = new ArrayList<>();
+        for (Map<?, ?> map : config.getMapList("loot")) {
+            GeyserLootEntry entry = GeyserLootEntry.parse(map);
+            if (entry != null) {
+                loot.add(entry);
+            }
+        }
+        return new GeyserLootTable(loot);
+    }
+
+    /**
+     * @return true if the table has no entries
+     */
+    public boolean isEmpty() {
+        return loot.isEmpty();
+    }
+
+    /**
+     * @return the raw loot table (do not mutate)
+     */
+    @NonNull
+    public List<GeyserLootEntry> getLoot() {
+        return loot;
+    }
+
+    /**
+     * Weighted roll honoring the vent's offering bias.
+     *
+     * @param random random source
+     * @param bias channel name to offering bias points
+     * @return the rolled entry, or null if the table is empty
+     */
+    @Nullable
+    public GeyserLootEntry roll(Random random, @NonNull Map<String, Integer> bias) {
+        double total = 0;
+        double[] weights = new double[loot.size()];
+        for (int i = 0; i < loot.size(); i++) {
+            weights[i] = effectiveWeight(loot.get(i), bias);
+            total += weights[i];
+        }
+        if (total <= 0) {
+            return null;
+        }
+        double roll = random.nextDouble() * total;
+        for (int i = 0; i < loot.size(); i++) {
+            roll -= weights[i];
+            if (roll < 0) {
+                return loot.get(i);
+            }
+        }
+        return loot.get(loot.size() - 1);
+    }
+
+    /**
+     * Effective weight of one entry given the vent's offering bias.
+     */
+    double effectiveWeight(GeyserLootEntry entry, @NonNull Map<String, Integer> bias) {
+        double weight = entry.weight();
+        if (entry.channel() != null) {
+            weight *= 1 + 0.5 * bias.getOrDefault(entry.channel(), 0);
+        }
+        return weight;
+    }
+
+    /**
+     * Map an offered material to a reward channel. Items with no channel still
+     * count towards the reward count but do not bias the table.
+     *
+     * @param material the offered material
+     * @return channel name or null
+     */
+    @Nullable
+    public static String categorize(Material material) {
+        String name = material.name().toUpperCase(Locale.ROOT);
+        // Gems first - more specific than ores
+        if (name.contains("DIAMOND") || name.contains("EMERALD") || name.contains("AMETHYST")
+                || name.contains("LAPIS") || name.contains("ENDER_PEARL")) {
+            return "gems";
+        }
+        if (name.contains("NETHER") || name.contains("SOUL_") || name.contains("MAGMA") || name.contains("BLAZE")
+                || name.contains("QUARTZ") || name.contains("GHAST") || name.contains("BASALT")
+                || name.contains("CRIMSON") || name.contains("WARPED")) {
+            return "nether";
+        }
+        if (name.endsWith("_ORE") || name.startsWith("RAW_") || name.endsWith("_INGOT") || name.endsWith("_NUGGET")
+                || name.equals("COAL") || name.equals("REDSTONE") || name.contains("STONE")
+                || name.contains("DEEPSLATE") || name.contains("GRANITE") || name.contains("DIORITE")
+                || name.contains("ANDESITE")) {
+            return "mineral";
+        }
+        if (name.endsWith("_LOG") || name.endsWith("_WOOD") || name.endsWith("_PLANKS") || name.endsWith("_SAPLING")
+                || name.endsWith("_LEAVES") || name.endsWith("_PROPAGULE") || name.contains("BAMBOO")
+                || name.contains("KELP")) {
+            return "forestry";
+        }
+        if (name.contains("WOOL") || name.contains("LEATHER") || name.equals("STRING") || name.contains("FEATHER")
+                || name.contains("EGG") || material.isEdible()) {
+            return "husbandry";
+        }
+        return null;
+    }
+}

--- a/src/main/java/world/bentobox/acidisland/geysers/GeyserOfferingsTask.java
+++ b/src/main/java/world/bentobox/acidisland/geysers/GeyserOfferingsTask.java
@@ -6,11 +6,13 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.World;
@@ -19,6 +21,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
+import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.Vector;
 import org.eclipse.jdt.annotation.Nullable;
@@ -64,6 +67,14 @@ public class GeyserOfferingsTask {
     private static final int POOL_SCAN_RADIUS = 3;
     /** Radius around the plume to look for a player to run command rewards for. */
     private static final double COMMAND_RANGE_SQUARED = 24.0 * 24;
+
+    /**
+     * PDC tag on spewed reward items. Tagged items are never consumed as
+     * offerings, so rewards that land back in the pool cannot be recycled into
+     * new offerings in a feedback loop. Once a player picks a reward up and
+     * rethrows it, it is a fresh untagged entity and sacrifices normally.
+     */
+    static final NamespacedKey REWARD_KEY = Objects.requireNonNull(NamespacedKey.fromString("acidisland:geyser_reward"));
 
     private static final Random RAND = new Random();
 
@@ -165,7 +176,7 @@ public class GeyserOfferingsTask {
      */
     private void consumeOfferings(World world) {
         for (Item item : world.getEntitiesByClass(Item.class)) {
-            if (item.getTicksLived() >= MIN_AGE_TICKS) {
+            if (item.getTicksLived() >= MIN_AGE_TICKS && !isReward(item)) {
                 Block start = waterStart(item);
                 Block vent = start == null ? null : findVentNear(start);
                 if (vent != null) {
@@ -173,6 +184,31 @@ public class GeyserOfferingsTask {
                 }
             }
         }
+    }
+
+    /**
+     * @return true if the item is a spewed reward that has not been picked up yet
+     */
+    private static boolean isReward(Item item) {
+        return item.getPersistentDataContainer().has(REWARD_KEY, PersistentDataType.BYTE);
+    }
+
+    /**
+     * Offer an item to a nearby vent on behalf of another consumer. Called by
+     * {@link world.bentobox.acidisland.world.AcidTask} when acid is about to
+     * destroy a floating item, so acid destruction within a vent's pool counts
+     * as a sacrifice instead of a plain loss.
+     *
+     * @param item the item about to be destroyed
+     * @return true if a vent consumed the item as an offering
+     */
+    public boolean offerToVent(Item item) {
+        if (task == null || isReward(item)) {
+            return false;
+        }
+        Block start = waterStart(item);
+        Block vent = start == null ? null : findVentNear(start);
+        return vent != null && sacrifice(item.getWorld(), item, vent);
     }
 
     /**
@@ -198,13 +234,15 @@ public class GeyserOfferingsTask {
 
     /**
      * Consume one offering: sizzle, credit the vent's bias, remove the item.
+     *
+     * @return true if the item was consumed, false if the event was cancelled
      */
-    private void sacrifice(World world, Item item, Block vent) {
+    private boolean sacrifice(World world, Item item, Block vent) {
         String channel = GeyserLootTable.categorize(item.getItemStack().getType());
         GeyserSacrificeEvent event = new GeyserSacrificeEvent(item, vent.getLocation(), channel);
         Bukkit.getPluginManager().callEvent(event);
         if (event.isCancelled()) {
-            return;
+            return false;
         }
         VentOfferings offerings = vents.computeIfAbsent(vent.getLocation().toVector(), k -> {
             VentOfferings v = new VentOfferings();
@@ -220,6 +258,7 @@ public class GeyserOfferingsTask {
         item.remove();
         world.playSound(item.getLocation(), Sound.BLOCK_FIRE_EXTINGUISH, 0.8F, 1.2F);
         world.spawnParticle(Particle.LARGE_SMOKE, item.getLocation(), 8, 0.2, 0.2, 0.2, 0.02);
+        return true;
     }
 
     /**
@@ -305,6 +344,7 @@ public class GeyserOfferingsTask {
      */
     private Item launchReward(World world, Location spawn, GeyserLootEntry entry) {
         Item item = world.dropItem(spawn, entry.toItemStack(RAND));
+        item.getPersistentDataContainer().set(REWARD_KEY, PersistentDataType.BYTE, (byte) 1);
         double angle = RAND.nextDouble() * 2 * Math.PI;
         double horizontal = 0.1 + RAND.nextDouble() * 0.3;
         item.setVelocity(new Vector(Math.cos(angle) * horizontal, 0.6 + RAND.nextDouble() * 0.6,

--- a/src/main/java/world/bentobox/acidisland/geysers/GeyserOfferingsTask.java
+++ b/src/main/java/world/bentobox/acidisland/geysers/GeyserOfferingsTask.java
@@ -1,0 +1,336 @@
+package world.bentobox.acidisland.geysers;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.Nullable;
+
+import world.bentobox.acidisland.AcidIsland;
+import world.bentobox.acidisland.events.GeyserSacrificeEvent;
+import world.bentobox.acidisland.events.GeyserTransmuteEvent;
+
+/**
+ * The geyser offerings mechanic: items thrown into the water around a sulfur
+ * vent are consumed with a sizzle as offerings, and when the vent's vanilla
+ * geyser next erupts, the offerings are transmuted into rewards spewed out of
+ * the plume. Rewards are rolled from the weighted {@code geyser-loot.yml}
+ * table, biased towards the channels of the materials sacrificed.
+ * <p>
+ * Eruptions are driven entirely by vanilla (Minecraft 26.2+ potent sulfur), so
+ * a once-a-second task watches fed vents for the block's
+ * {@code potent_sulfur_state} to pass through {@code erupting}; the rewards pay
+ * out as the plume settles so the eruption itself cannot fling them away. On
+ * older servers the mechanic is inert.
+ *
+ * @author tastybento
+ * @since 2.1.0
+ */
+public class GeyserOfferingsTask {
+
+    // Only exists on Minecraft 26.2 and later; null on older servers, which disables the mechanic
+    private static final Material POTENT_SULFUR = Material.getMaterial("POTENT_SULFUR");
+    private static final String ERUPTING_STATE = "potent_sulfur_state=erupting";
+    /**
+     * Minimum age in ticks before a floating item is consumed, so freshly
+     * spewed rewards can clear the pool before the vent eats them back.
+     */
+    private static final int MIN_AGE_TICKS = 60;
+    /** How far below a floating item to look for a vent cap (vent depth + twin vent offset). */
+    private static final int POOL_SCAN_DEPTH = 4;
+    /**
+     * Horizontal radius around a floating item to look for a vent cap.
+     * Floating items bob and drift, so requiring them to sit in the exact
+     * one-block column above the cap makes offerings nearly impossible to
+     * land - anywhere in the pool around the vent counts instead.
+     */
+    private static final int POOL_SCAN_RADIUS = 3;
+    /** Radius around the plume to look for a player to run command rewards for. */
+    private static final double COMMAND_RANGE_SQUARED = 24 * 24;
+
+    private static final Random RAND = new Random();
+
+    /**
+     * Offerings pending at one vent: reward channel bias, the number of items
+     * sacrificed, and the eruption state seen last tick.
+     */
+    static class VentOfferings {
+        final Map<String, Integer> bias = new HashMap<>();
+        int items;
+        boolean erupting;
+    }
+
+    private final AcidIsland addon;
+    private final @Nullable GeyserLootTable table;
+    private final @Nullable BukkitTask task;
+    private final Map<Vector, VentOfferings> vents = new HashMap<>();
+
+    /**
+     * Runs the repeating task that consumes offerings and pays out rewards.
+     * Does nothing if the mechanic is disabled in config, the server predates
+     * Minecraft 26.2, or the loot table is empty.
+     *
+     * @param addon - addon
+     */
+    public GeyserOfferingsTask(AcidIsland addon) {
+        this.addon = addon;
+        if (!addon.getSettings().isGeyserOfferings()) {
+            table = null;
+            task = null;
+            return;
+        }
+        if (POTENT_SULFUR == null) {
+            addon.log("Geyser offerings require Minecraft 26.2 or later - mechanic disabled.");
+            table = null;
+            task = null;
+            return;
+        }
+        table = loadTable();
+        if (table.isEmpty()) {
+            addon.logError("geyser-loot.yml has no valid loot entries - geyser offerings disabled.");
+            task = null;
+            return;
+        }
+        task = Bukkit.getScheduler().runTaskTimer(addon.getPlugin(), this::tick, 20L, 20L);
+        addon.log("Geyser offerings active: " + table.getLoot().size() + " loot entries, max "
+                + addon.getSettings().getGeyserMaxRewards() + " rewards per eruption.");
+    }
+
+    private GeyserLootTable loadTable() {
+        File file = new File(addon.getDataFolder(), "geyser-loot.yml");
+        if (!file.exists()) {
+            addon.saveResource("geyser-loot.yml", false);
+        }
+        return GeyserLootTable.parse(YamlConfiguration.loadConfiguration(file));
+    }
+
+    /**
+     * One tick (1s): consume floating offerings, then watch fed vents for the
+     * end of an eruption.
+     */
+    void tick() {
+        World world = addon.getOverWorld();
+        if (world == null) {
+            return;
+        }
+        consumeOfferings(world);
+        watchVents(world);
+    }
+
+    /**
+     * @return true if the material is part of a vent's water column. The
+     * magma block and bubbling potent sulfur can turn the water above a vent
+     * into bubble column blocks, so those count as water here.
+     */
+    private static boolean isWaterLike(Material type) {
+        return type == Material.WATER || type == Material.BUBBLE_COLUMN;
+    }
+
+    /**
+     * The water block an item is floating in or on. Items bob on the surface,
+     * so the item's own block is often the air block just above the water.
+     *
+     * @param item the floating item
+     * @return the water(-like) block to scan down from, or null if the item is
+     * not in or on water
+     */
+    private @Nullable Block waterStart(Item item) {
+        Block block = item.getLocation().getBlock();
+        if (isWaterLike(block.getType())) {
+            return block;
+        }
+        Block below = block.getRelative(BlockFace.DOWN);
+        return isWaterLike(below.getType()) ? below : null;
+    }
+
+    /**
+     * Consume items floating in the water around a vent cap as offerings.
+     */
+    private void consumeOfferings(World world) {
+        for (Item item : world.getEntitiesByClass(Item.class)) {
+            if (item.getTicksLived() < MIN_AGE_TICKS) {
+                continue;
+            }
+            Block start = waterStart(item);
+            if (start == null) {
+                continue;
+            }
+            Block vent = findVentNear(start);
+            if (vent != null) {
+                sacrifice(world, item, vent);
+            }
+        }
+    }
+
+    /**
+     * Look for a potent sulfur cap in the pool below and around a floating
+     * item. Scans shallowest layer first so a twin vent's main cap wins.
+     *
+     * @param start the water block the floating item is in
+     * @return the nearest vent cap block, or null if the item is not near a vent
+     */
+    private @Nullable Block findVentNear(Block start) {
+        for (int dy = 1; dy <= POOL_SCAN_DEPTH; dy++) {
+            for (int dx = -POOL_SCAN_RADIUS; dx <= POOL_SCAN_RADIUS; dx++) {
+                for (int dz = -POOL_SCAN_RADIUS; dz <= POOL_SCAN_RADIUS; dz++) {
+                    Block block = start.getRelative(dx, -dy, dz);
+                    if (block.getType() == POTENT_SULFUR) {
+                        return block;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Consume one offering: sizzle, credit the vent's bias, remove the item.
+     */
+    private void sacrifice(World world, Item item, Block vent) {
+        String channel = GeyserLootTable.categorize(item.getItemStack().getType());
+        GeyserSacrificeEvent event = new GeyserSacrificeEvent(item, vent.getLocation(), channel);
+        Bukkit.getPluginManager().callEvent(event);
+        if (event.isCancelled()) {
+            return;
+        }
+        VentOfferings offerings = vents.computeIfAbsent(vent.getLocation().toVector(), k -> {
+            VentOfferings v = new VentOfferings();
+            v.erupting = isErupting(vent);
+            return v;
+        });
+        int amount = item.getItemStack().getAmount();
+        offerings.items += amount;
+        if (channel != null) {
+            offerings.bias.merge(channel, amount, Integer::sum);
+        }
+        // Consumed either way - the geyser is not a storage unit
+        item.remove();
+        world.playSound(item.getLocation(), Sound.BLOCK_FIRE_EXTINGUISH, 0.8F, 1.2F);
+        world.spawnParticle(Particle.LARGE_SMOKE, item.getLocation(), 8, 0.2, 0.2, 0.2, 0.02);
+    }
+
+    /**
+     * Watch fed vents: when a vent that was erupting settles again, spew the
+     * transmuted rewards. Vents that have been mined out forfeit their
+     * offerings.
+     */
+    private void watchVents(World world) {
+        Iterator<Map.Entry<Vector, VentOfferings>> it = vents.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<Vector, VentOfferings> entry = it.next();
+            Vector v = entry.getKey();
+            if (!world.isChunkLoaded(v.getBlockX() >> 4, v.getBlockZ() >> 4)) {
+                continue;
+            }
+            Block vent = world.getBlockAt(v.getBlockX(), v.getBlockY(), v.getBlockZ());
+            if (vent.getType() != POTENT_SULFUR) {
+                it.remove();
+                continue;
+            }
+            boolean erupting = isErupting(vent);
+            VentOfferings offerings = entry.getValue();
+            if (offerings.erupting && !erupting) {
+                // The plume has settled - pay out now so the eruption cannot
+                // fling the rewards far from the vent
+                it.remove();
+                spew(world, vent, offerings);
+            } else {
+                offerings.erupting = erupting;
+            }
+        }
+    }
+
+    private boolean isErupting(Block vent) {
+        return vent.getBlockData().getAsString().contains(ERUPTING_STATE);
+    }
+
+    /**
+     * Transmute a vent's offerings into rewards and spew them from the water
+     * surface with a radial launch.
+     */
+    private void spew(World world, Block vent, VentOfferings offerings) {
+        // Find the surface above the vent
+        Block top = vent.getRelative(BlockFace.UP);
+        while (isWaterLike(top.getType()) && top.getY() < world.getMaxHeight()) {
+            top = top.getRelative(BlockFace.UP);
+        }
+        Location spawn = top.getLocation().add(0.5, 0.5, 0.5);
+        int rolls = Math.clamp(offerings.items, 1, Math.max(1, addon.getSettings().getGeyserMaxRewards()));
+        List<Item> rewards = new ArrayList<>(rolls);
+        for (int i = 0; i < rolls; i++) {
+            GeyserLootEntry entry = table.roll(RAND, offerings.bias);
+            if (entry == null) {
+                break;
+            }
+            if (entry.isCommand()) {
+                executeReward(world, spawn, entry);
+                continue;
+            }
+            Item item = world.dropItem(spawn, entry.toItemStack(RAND));
+            // Radial launch: guaranteed outward motion so the rewards scatter
+            // around the vent instead of falling straight back into the pool
+            double angle = RAND.nextDouble() * 2 * Math.PI;
+            double horizontal = 0.1 + RAND.nextDouble() * 0.3;
+            item.setVelocity(new Vector(Math.cos(angle) * horizontal, 0.6 + RAND.nextDouble() * 0.6,
+                    Math.sin(angle) * horizontal));
+            rewards.add(item);
+        }
+        world.playSound(spawn, Sound.ENTITY_GENERIC_SPLASH, 1F, 1F);
+        world.spawnParticle(Particle.SPLASH, spawn, 40, 0.4, 0.6, 0.4, 0.2);
+        Bukkit.getPluginManager().callEvent(new GeyserTransmuteEvent(vent.getLocation(), rewards, offerings.items));
+    }
+
+    /**
+     * Execute a command reward for the nearest player to the vent, if any is
+     * close enough to have witnessed the eruption.
+     */
+    private void executeReward(World world, Location spawn, GeyserLootEntry entry) {
+        world.getPlayers().stream()
+                .filter(p -> p.getLocation().distanceSquared(spawn) <= COMMAND_RANGE_SQUARED)
+                .min((a, b) -> Double.compare(a.getLocation().distanceSquared(spawn),
+                        b.getLocation().distanceSquared(spawn)))
+                .map(Player::getName)
+                .ifPresent(name -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(),
+                        entry.command().replace("%player%", name)));
+    }
+
+    /**
+     * Cancel the repeating task, if it is running.
+     */
+    public void cancelTasks() {
+        if (task != null) {
+            task.cancel();
+        }
+    }
+
+    /**
+     * @return the pending offerings per vent (package-private for testing)
+     */
+    Map<Vector, VentOfferings> getVents() {
+        return vents;
+    }
+
+    /**
+     * @return true if the repeating task was scheduled (package-private for testing)
+     */
+    boolean isRunning() {
+        return task != null;
+    }
+}

--- a/src/main/java/world/bentobox/acidisland/geysers/GeyserOfferingsTask.java
+++ b/src/main/java/world/bentobox/acidisland/geysers/GeyserOfferingsTask.java
@@ -63,7 +63,7 @@ public class GeyserOfferingsTask {
      */
     private static final int POOL_SCAN_RADIUS = 3;
     /** Radius around the plume to look for a player to run command rewards for. */
-    private static final double COMMAND_RANGE_SQUARED = 24 * 24;
+    private static final double COMMAND_RANGE_SQUARED = 24.0 * 24;
 
     private static final Random RAND = new Random();
 
@@ -165,16 +165,12 @@ public class GeyserOfferingsTask {
      */
     private void consumeOfferings(World world) {
         for (Item item : world.getEntitiesByClass(Item.class)) {
-            if (item.getTicksLived() < MIN_AGE_TICKS) {
-                continue;
-            }
-            Block start = waterStart(item);
-            if (start == null) {
-                continue;
-            }
-            Block vent = findVentNear(start);
-            if (vent != null) {
-                sacrifice(world, item, vent);
+            if (item.getTicksLived() >= MIN_AGE_TICKS) {
+                Block start = waterStart(item);
+                Block vent = start == null ? null : findVentNear(start);
+                if (vent != null) {
+                    sacrifice(world, item, vent);
+                }
             }
         }
     }
@@ -235,26 +231,38 @@ public class GeyserOfferingsTask {
         Iterator<Map.Entry<Vector, VentOfferings>> it = vents.entrySet().iterator();
         while (it.hasNext()) {
             Map.Entry<Vector, VentOfferings> entry = it.next();
-            Vector v = entry.getKey();
-            if (!world.isChunkLoaded(v.getBlockX() >> 4, v.getBlockZ() >> 4)) {
-                continue;
-            }
-            Block vent = world.getBlockAt(v.getBlockX(), v.getBlockY(), v.getBlockZ());
-            if (vent.getType() != POTENT_SULFUR) {
+            if (checkVent(world, entry.getKey(), entry.getValue())) {
                 it.remove();
-                continue;
-            }
-            boolean erupting = isErupting(vent);
-            VentOfferings offerings = entry.getValue();
-            if (offerings.erupting && !erupting) {
-                // The plume has settled - pay out now so the eruption cannot
-                // fling the rewards far from the vent
-                it.remove();
-                spew(world, vent, offerings);
-            } else {
-                offerings.erupting = erupting;
             }
         }
+    }
+
+    /**
+     * Check one fed vent, spewing its rewards if its eruption has settled.
+     *
+     * @param world the overworld
+     * @param v the vent cap position
+     * @param offerings the vent's pending offerings
+     * @return true if the vent's tracking entry should be dropped
+     */
+    private boolean checkVent(World world, Vector v, VentOfferings offerings) {
+        if (!world.isChunkLoaded(v.getBlockX() >> 4, v.getBlockZ() >> 4)) {
+            return false;
+        }
+        Block vent = world.getBlockAt(v.getBlockX(), v.getBlockY(), v.getBlockZ());
+        if (vent.getType() != POTENT_SULFUR) {
+            // Mined out - offerings forfeited
+            return true;
+        }
+        boolean erupting = isErupting(vent);
+        if (offerings.erupting && !erupting) {
+            // The plume has settled - pay out now so the eruption cannot
+            // fling the rewards far from the vent
+            spew(world, vent, offerings);
+            return true;
+        }
+        offerings.erupting = erupting;
+        return false;
     }
 
     private boolean isErupting(Block vent) {
@@ -281,20 +289,27 @@ public class GeyserOfferingsTask {
             }
             if (entry.isCommand()) {
                 executeReward(world, spawn, entry);
-                continue;
+            } else {
+                rewards.add(launchReward(world, spawn, entry));
             }
-            Item item = world.dropItem(spawn, entry.toItemStack(RAND));
-            // Radial launch: guaranteed outward motion so the rewards scatter
-            // around the vent instead of falling straight back into the pool
-            double angle = RAND.nextDouble() * 2 * Math.PI;
-            double horizontal = 0.1 + RAND.nextDouble() * 0.3;
-            item.setVelocity(new Vector(Math.cos(angle) * horizontal, 0.6 + RAND.nextDouble() * 0.6,
-                    Math.sin(angle) * horizontal));
-            rewards.add(item);
         }
         world.playSound(spawn, Sound.ENTITY_GENERIC_SPLASH, 1F, 1F);
         world.spawnParticle(Particle.SPLASH, spawn, 40, 0.4, 0.6, 0.4, 0.2);
         Bukkit.getPluginManager().callEvent(new GeyserTransmuteEvent(vent.getLocation(), rewards, offerings.items));
+    }
+
+    /**
+     * Spawn one reward item at the plume top with a radial launch: guaranteed
+     * outward motion so the rewards scatter around the vent instead of falling
+     * straight back into the pool.
+     */
+    private Item launchReward(World world, Location spawn, GeyserLootEntry entry) {
+        Item item = world.dropItem(spawn, entry.toItemStack(RAND));
+        double angle = RAND.nextDouble() * 2 * Math.PI;
+        double horizontal = 0.1 + RAND.nextDouble() * 0.3;
+        item.setVelocity(new Vector(Math.cos(angle) * horizontal, 0.6 + RAND.nextDouble() * 0.6,
+                Math.sin(angle) * horizontal));
+        return item;
     }
 
     /**

--- a/src/main/java/world/bentobox/acidisland/world/AcidTask.java
+++ b/src/main/java/world/bentobox/acidisland/world/AcidTask.java
@@ -27,6 +27,7 @@ import world.bentobox.acidisland.AcidIsland;
 import world.bentobox.acidisland.events.EntityDamageByAcidEvent;
 import world.bentobox.acidisland.events.EntityDamageByAcidEvent.Acid;
 import world.bentobox.acidisland.events.ItemDestroyByAcidEvent;
+import world.bentobox.acidisland.geysers.GeyserOfferingsTask;
 import world.bentobox.acidisland.listeners.AcidEffect;
 
 public class AcidTask {
@@ -103,9 +104,15 @@ public class AcidTask {
             if (e.getLocation().getBlock().getType().equals(Material.WATER)) {
                 itemsInWater.putIfAbsent(e, damage + addon.getSettings().getAcidDestroyItemTime() * 1000);
                 if (System.currentTimeMillis() > itemsInWater.get(e)) {
+                    itemsInWater.remove(e);
+                    // Items dissolving within a vent's pool are counted as
+                    // offerings rather than lost to the acid
+                    GeyserOfferingsTask geysers = addon.getGeyserOfferingsTask();
+                    if (geysers != null && geysers.offerToVent(item)) {
+                        return;
+                    }
                     e.getWorld().playSound(e.getLocation(), Sound.ENTITY_CREEPER_PRIMED, 3F, 3F);
                     e.remove();
-                    itemsInWater.remove(e);
                     // Fire event
                     Bukkit.getPluginManager().callEvent(new ItemDestroyByAcidEvent(item));
                 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -163,8 +163,8 @@ world:
   # Sulfur vents
   # Chance (0-100) per chunk of a sulfur vent generating just below the sea surface.
   # Vents are made of potent sulfur over a magma block and bubble, gas, and erupt as geysers.
+  # Changing this only affects newly generated chunks.
   # Requires Minecraft 26.2 or later - ignored on older servers.
-  # /!\ BentoBox currently does not support changing this value mid-game. If you do need to change it, do a full reset of your databases and worlds.
   sulfur-vent-chance: 10
   # Geyser offerings
   # Items thrown into the water around a sulfur vent are consumed as offerings and

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -170,6 +170,8 @@ world:
   # Items thrown into the water around a sulfur vent are consumed as offerings and
   # transmuted into rewards that are spewed out when the vent next erupts as a geyser.
   # Rewards are defined in geyser-loot.yml in the addon's data folder.
+  # Works with acid item destruction: items the acid destroys within a vent's pool
+  # count as offerings instead of being lost.
   # Requires Minecraft 26.2 or later - ignored on older servers.
   geyser-offerings:
     enabled: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -166,6 +166,15 @@ world:
   # Requires Minecraft 26.2 or later - ignored on older servers.
   # /!\ BentoBox currently does not support changing this value mid-game. If you do need to change it, do a full reset of your databases and worlds.
   sulfur-vent-chance: 10
+  # Geyser offerings
+  # Items thrown into the water around a sulfur vent are consumed as offerings and
+  # transmuted into rewards that are spewed out when the vent next erupts as a geyser.
+  # Rewards are defined in geyser-loot.yml in the addon's data folder.
+  # Requires Minecraft 26.2 or later - ignored on older servers.
+  geyser-offerings:
+    enabled: true
+    # Maximum number of rewards a single eruption can spew, however many items were offered.
+    max-rewards: 12
   # Structures
   # This creates an vanilla structures in the worlds.
   # Trial chambers and other underground structures generate buried

--- a/src/main/resources/geyser-loot.yml
+++ b/src/main/resources/geyser-loot.yml
@@ -1,0 +1,61 @@
+# Geyser offering rewards
+#
+# Items thrown into the water around a sulfur vent are consumed as offerings.
+# When the vent next erupts, one reward is rolled per item offered (capped by
+# world.geyser-offerings.max-rewards in config.yml) and spewed from the plume.
+#
+# Each entry is either an item or a console command:
+#   - {item: RAW_IRON, weight: 30, channel: mineral, amount: {min: 1, max: 3}}
+#   - {command: "give %player% cod 1", weight: 1}
+# weight   - relative chance of the entry rolling (higher = more common)
+# channel  - optional. Offerings bias the table towards their own channel:
+#            every item sacrificed in a channel adds +50% to that channel's
+#            entry weights for the payout. Channels are assigned by material:
+#            gems      - diamonds, emeralds, amethyst, lapis, ender pearls
+#            nether    - netherrack, quartz, blaze, magma, soul, crimson/warped
+#            mineral   - ores, raw metals, ingots, nuggets, stone types
+#            forestry  - logs, planks, saplings, leaves, bamboo, kelp
+#            husbandry - wool, leather, string, feathers, eggs, any food
+#            Anything else burns with no bias but still counts as an offering.
+# amount   - optional item count, fixed or a {min, max} range (default 1)
+#
+# The geyser gives back what it is fed, changed: sacrifice ores to be paid in
+# gems, sacrifice wood to be paid in living things. Materials from Minecraft
+# 26.2 (SULFUR, CINNABAR) are safe to list - this file is only loaded on
+# servers that support the mechanic.
+loot:
+  # The vent's own produce - always in the mix
+  - {item: SULFUR, weight: 25, amount: {min: 1, max: 3}}
+  - {item: CINNABAR, weight: 12, amount: {min: 1, max: 2}}
+  - {item: MAGMA_BLOCK, weight: 10}
+  - {item: PRISMARINE_SHARD, weight: 15, amount: {min: 1, max: 2}}
+  - {item: PRISMARINE_CRYSTALS, weight: 8}
+  - {item: SEA_PICKLE, weight: 6}
+  - {item: NAUTILUS_SHELL, weight: 3}
+  - {item: HEART_OF_THE_SEA, weight: 1}
+  # Mineral channel - fed by stone, ores and metals
+  - {item: IRON_NUGGET, weight: 20, channel: mineral, amount: {min: 2, max: 5}}
+  - {item: RAW_COPPER, weight: 15, channel: mineral, amount: {min: 1, max: 3}}
+  - {item: RAW_IRON, weight: 12, channel: mineral, amount: {min: 1, max: 2}}
+  - {item: RAW_GOLD, weight: 6, channel: mineral}
+  - {item: REDSTONE, weight: 8, channel: mineral, amount: {min: 1, max: 4}}
+  # Gems channel - the vent's rarest vein
+  - {item: AMETHYST_SHARD, weight: 8, channel: gems, amount: {min: 1, max: 2}}
+  - {item: LAPIS_LAZULI, weight: 8, channel: gems, amount: {min: 2, max: 4}}
+  - {item: EMERALD, weight: 3, channel: gems}
+  - {item: DIAMOND, weight: 2, channel: gems}
+  # Nether channel - heat calls to heat
+  - {item: QUARTZ, weight: 10, channel: nether, amount: {min: 1, max: 3}}
+  - {item: GLOWSTONE_DUST, weight: 8, channel: nether, amount: {min: 1, max: 2}}
+  - {item: BLAZE_POWDER, weight: 4, channel: nether}
+  - {item: ANCIENT_DEBRIS, weight: 1, channel: nether}
+  # Forestry channel - green things from a dead sea
+  - {item: KELP, weight: 12, channel: forestry, amount: {min: 1, max: 3}}
+  - {item: BAMBOO, weight: 8, channel: forestry, amount: {min: 1, max: 4}}
+  - {item: MANGROVE_PROPAGULE, weight: 5, channel: forestry}
+  - {item: OAK_SAPLING, weight: 5, channel: forestry}
+  # Husbandry channel - the boiled bounty of the deep
+  - {item: COOKED_COD, weight: 12, channel: husbandry, amount: {min: 1, max: 2}}
+  - {item: COOKED_SALMON, weight: 8, channel: husbandry}
+  - {item: LEATHER, weight: 6, channel: husbandry, amount: {min: 1, max: 2}}
+  - {item: TURTLE_EGG, weight: 2, channel: husbandry}

--- a/src/test/java/world/bentobox/acidisland/AISettingsTest.java
+++ b/src/test/java/world/bentobox/acidisland/AISettingsTest.java
@@ -110,6 +110,20 @@ public class AISettingsTest {
     }
 
     @Test
+    void testIsGeyserOfferings() {
+        assertTrue(s.isGeyserOfferings());
+        s.setGeyserOfferings(false);
+        assertFalse(s.isGeyserOfferings());
+    }
+
+    @Test
+    void testGetGeyserMaxRewards() {
+        assertEquals(12, s.getGeyserMaxRewards());
+        s.setGeyserMaxRewards(20);
+        assertEquals(20, s.getGeyserMaxRewards());
+    }
+
+    @Test
     void testGetDifficulty() {
         assertEquals(Difficulty.NORMAL, s.getDifficulty());
     }

--- a/src/test/java/world/bentobox/acidisland/events/GeyserSacrificeEventTest.java
+++ b/src/test/java/world/bentobox/acidisland/events/GeyserSacrificeEventTest.java
@@ -1,0 +1,66 @@
+package world.bentobox.acidisland.events;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Item;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author tastybento
+ */
+@ExtendWith(MockitoExtension.class)
+public class GeyserSacrificeEventTest {
+
+    @Mock
+    private Item item;
+    @Mock
+    private Location vent;
+    private GeyserSacrificeEvent event;
+
+    @BeforeEach
+    void setUp() {
+        event = new GeyserSacrificeEvent(item, vent, "gems");
+    }
+
+    @Test
+    void testGetItem() {
+        assertEquals(item, event.getItem());
+    }
+
+    @Test
+    void testGetVent() {
+        assertEquals(vent, event.getVent());
+    }
+
+    @Test
+    void testGetChannel() {
+        assertEquals("gems", event.getChannel());
+        assertNull(new GeyserSacrificeEvent(item, vent, null).getChannel());
+    }
+
+    @Test
+    void testCancellation() {
+        assertFalse(event.isCancelled());
+        event.setCancelled(true);
+        assertTrue(event.isCancelled());
+    }
+
+    @Test
+    void testGetHandlers() {
+        assertNotNull(event.getHandlers());
+    }
+
+    @Test
+    void testGetHandlerList() {
+        assertNotNull(GeyserSacrificeEvent.getHandlerList());
+    }
+}

--- a/src/test/java/world/bentobox/acidisland/events/GeyserSacrificeEventTest.java
+++ b/src/test/java/world/bentobox/acidisland/events/GeyserSacrificeEventTest.java
@@ -18,7 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author tastybento
  */
 @ExtendWith(MockitoExtension.class)
-public class GeyserSacrificeEventTest {
+class GeyserSacrificeEventTest {
 
     @Mock
     private Item item;

--- a/src/test/java/world/bentobox/acidisland/events/GeyserTransmuteEventTest.java
+++ b/src/test/java/world/bentobox/acidisland/events/GeyserTransmuteEventTest.java
@@ -1,0 +1,57 @@
+package world.bentobox.acidisland.events;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Item;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author tastybento
+ */
+@ExtendWith(MockitoExtension.class)
+public class GeyserTransmuteEventTest {
+
+    @Mock
+    private Item item;
+    @Mock
+    private Location vent;
+    private GeyserTransmuteEvent event;
+
+    @BeforeEach
+    void setUp() {
+        event = new GeyserTransmuteEvent(vent, List.of(item), 5);
+    }
+
+    @Test
+    void testGetVent() {
+        assertEquals(vent, event.getVent());
+    }
+
+    @Test
+    void testGetRewards() {
+        assertEquals(List.of(item), event.getRewards());
+    }
+
+    @Test
+    void testGetOfferings() {
+        assertEquals(5, event.getOfferings());
+    }
+
+    @Test
+    void testGetHandlers() {
+        assertNotNull(event.getHandlers());
+    }
+
+    @Test
+    void testGetHandlerList() {
+        assertNotNull(GeyserTransmuteEvent.getHandlerList());
+    }
+}

--- a/src/test/java/world/bentobox/acidisland/events/GeyserTransmuteEventTest.java
+++ b/src/test/java/world/bentobox/acidisland/events/GeyserTransmuteEventTest.java
@@ -17,7 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author tastybento
  */
 @ExtendWith(MockitoExtension.class)
-public class GeyserTransmuteEventTest {
+class GeyserTransmuteEventTest {
 
     @Mock
     private Item item;

--- a/src/test/java/world/bentobox/acidisland/geysers/GeyserLootEntryTest.java
+++ b/src/test/java/world/bentobox/acidisland/geysers/GeyserLootEntryTest.java
@@ -28,7 +28,7 @@ import org.mockito.quality.Strictness;
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class GeyserLootEntryTest {
+class GeyserLootEntryTest {
 
     private ServerMock server;
     private MockedStatic<Bukkit> mockedBukkit;

--- a/src/test/java/world/bentobox/acidisland/geysers/GeyserLootEntryTest.java
+++ b/src/test/java/world/bentobox/acidisland/geysers/GeyserLootEntryTest.java
@@ -1,0 +1,113 @@
+package world.bentobox.acidisland.geysers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Random;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * @author tastybento
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class GeyserLootEntryTest {
+
+    private ServerMock server;
+    private MockedStatic<Bukkit> mockedBukkit;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        mockedBukkit = Mockito.mockStatic(Bukkit.class, Mockito.RETURNS_DEEP_STUBS);
+        mockedBukkit.when(Bukkit::getMinecraftVersion).thenReturn("1.21.11");
+        mockedBukkit.when(Bukkit::getServer).thenReturn(server);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedBukkit.closeOnDemand();
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void testParseItemEntry() {
+        GeyserLootEntry entry = GeyserLootEntry.parse(
+                Map.of("item", "RAW_IRON", "weight", 30, "channel", "MINERAL", "amount", Map.of("min", 1, "max", 3)));
+        assertEquals(Material.RAW_IRON, entry.material());
+        assertNull(entry.command());
+        assertEquals(30, entry.weight());
+        assertEquals("mineral", entry.channel());
+        assertEquals(1, entry.min());
+        assertEquals(3, entry.max());
+        assertFalse(entry.isCommand());
+    }
+
+    @Test
+    void testParseFixedAmount() {
+        GeyserLootEntry entry = GeyserLootEntry.parse(Map.of("item", "KELP", "amount", 4));
+        assertEquals(4, entry.min());
+        assertEquals(4, entry.max());
+        assertEquals(1, entry.weight());
+        assertNull(entry.channel());
+    }
+
+    @Test
+    void testParseCommandEntry() {
+        GeyserLootEntry entry = GeyserLootEntry.parse(Map.of("command", "give %player% cod 1", "weight", 2));
+        assertTrue(entry.isCommand());
+        assertEquals("give %player% cod 1", entry.command());
+        assertNull(entry.material());
+        assertEquals(2, entry.weight());
+    }
+
+    @Test
+    void testParseUnknownMaterial() {
+        assertNull(GeyserLootEntry.parse(Map.of("item", "NOT_A_MATERIAL", "weight", 5)));
+    }
+
+    @Test
+    void testParseMissingItemAndCommand() {
+        assertNull(GeyserLootEntry.parse(Map.of("weight", 5)));
+    }
+
+    @Test
+    void testParseBlankCommand() {
+        assertNull(GeyserLootEntry.parse(Map.of("command", " ")));
+    }
+
+    @Test
+    void testToItemStackRange() {
+        GeyserLootEntry entry = new GeyserLootEntry(Material.IRON_NUGGET, null, 1, null, 2, 5);
+        Random random = new Random(42);
+        for (int i = 0; i < 50; i++) {
+            ItemStack stack = entry.toItemStack(random);
+            assertEquals(Material.IRON_NUGGET, stack.getType());
+            assertTrue(stack.getAmount() >= 2 && stack.getAmount() <= 5,
+                    "Amount out of range: " + stack.getAmount());
+        }
+    }
+
+    @Test
+    void testToItemStackFixedAmount() {
+        GeyserLootEntry entry = new GeyserLootEntry(Material.DIAMOND, null, 1, "gems", 1, 1);
+        assertEquals(1, entry.toItemStack(new Random(42)).getAmount());
+    }
+}

--- a/src/test/java/world/bentobox/acidisland/geysers/GeyserLootTableTest.java
+++ b/src/test/java/world/bentobox/acidisland/geysers/GeyserLootTableTest.java
@@ -29,7 +29,7 @@ import org.mockito.quality.Strictness;
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class GeyserLootTableTest {
+class GeyserLootTableTest {
 
     private ServerMock server;
     private MockedStatic<Bukkit> mockedBukkit;

--- a/src/test/java/world/bentobox/acidisland/geysers/GeyserLootTableTest.java
+++ b/src/test/java/world/bentobox/acidisland/geysers/GeyserLootTableTest.java
@@ -1,0 +1,169 @@
+package world.bentobox.acidisland.geysers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Random;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * @author tastybento
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class GeyserLootTableTest {
+
+    private ServerMock server;
+    private MockedStatic<Bukkit> mockedBukkit;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        mockedBukkit = Mockito.mockStatic(Bukkit.class, Mockito.RETURNS_DEEP_STUBS);
+        mockedBukkit.when(Bukkit::getMinecraftVersion).thenReturn("1.21.11");
+        mockedBukkit.when(Bukkit::getServer).thenReturn(server);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedBukkit.closeOnDemand();
+        MockBukkit.unmock();
+    }
+
+    private static final String YAML = """
+            loot:
+              - {item: PRISMARINE_SHARD, weight: 10}
+              - {item: DIAMOND, weight: 2, channel: gems}
+              - {item: RAW_IRON, weight: 8, channel: mineral, amount: {min: 1, max: 3}}
+              - {item: NOT_A_MATERIAL, weight: 100}
+            """;
+
+    private GeyserLootTable load(String yaml) throws InvalidConfigurationException {
+        YamlConfiguration config = new YamlConfiguration();
+        config.loadFromString(yaml);
+        return GeyserLootTable.parse(config);
+    }
+
+    @Test
+    void testParseDropsInvalidEntries() throws InvalidConfigurationException {
+        GeyserLootTable table = load(YAML);
+        assertFalse(table.isEmpty());
+        assertEquals(3, table.getLoot().size());
+    }
+
+    @Test
+    void testParseEmpty() throws InvalidConfigurationException {
+        GeyserLootTable table = load("loot: []");
+        assertTrue(table.isEmpty());
+        assertNull(table.roll(new Random(42), Map.of()));
+    }
+
+    @Test
+    void testEffectiveWeightNoChannel() throws InvalidConfigurationException {
+        GeyserLootTable table = load(YAML);
+        GeyserLootEntry plain = table.getLoot().get(0);
+        // Bias never changes un-channeled entries
+        assertEquals(10.0, table.effectiveWeight(plain, Map.of("gems", 100)));
+    }
+
+    @Test
+    void testEffectiveWeightBias() throws InvalidConfigurationException {
+        GeyserLootTable table = load(YAML);
+        GeyserLootEntry gems = table.getLoot().get(1);
+        assertEquals(2.0, table.effectiveWeight(gems, Map.of()));
+        // Each offering point adds +50% of the base weight
+        assertEquals(2.0 * (1 + 0.5 * 4), table.effectiveWeight(gems, Map.of("gems", 4)));
+        // Bias on another channel does nothing
+        assertEquals(2.0, table.effectiveWeight(gems, Map.of("mineral", 4)));
+    }
+
+    @Test
+    void testRollHonorsBias() throws InvalidConfigurationException {
+        GeyserLootTable table = load(YAML);
+        Random random = new Random(42);
+        // Overwhelming gems bias means gems should dominate the rolls
+        int gems = 0;
+        for (int i = 0; i < 100; i++) {
+            GeyserLootEntry entry = table.roll(random, Map.of("gems", 1000));
+            if ("gems".equals(entry.channel())) {
+                gems++;
+            }
+        }
+        assertTrue(gems > 90, "Expected gems to dominate but rolled only " + gems);
+    }
+
+    @Test
+    void testRollUnbiased() throws InvalidConfigurationException {
+        GeyserLootTable table = load(YAML);
+        Random random = new Random(42);
+        for (int i = 0; i < 100; i++) {
+            assertTrue(table.getLoot().contains(table.roll(random, Map.of())));
+        }
+    }
+
+    @Test
+    void testCategorizeGems() {
+        assertEquals("gems", GeyserLootTable.categorize(Material.DIAMOND));
+        assertEquals("gems", GeyserLootTable.categorize(Material.EMERALD_BLOCK));
+        assertEquals("gems", GeyserLootTable.categorize(Material.AMETHYST_SHARD));
+        assertEquals("gems", GeyserLootTable.categorize(Material.ENDER_PEARL));
+    }
+
+    @Test
+    void testCategorizeNether() {
+        assertEquals("nether", GeyserLootTable.categorize(Material.NETHERRACK));
+        assertEquals("nether", GeyserLootTable.categorize(Material.QUARTZ));
+        assertEquals("nether", GeyserLootTable.categorize(Material.BLAZE_ROD));
+        assertEquals("nether", GeyserLootTable.categorize(Material.MAGMA_BLOCK));
+    }
+
+    @Test
+    void testCategorizeMineral() {
+        assertEquals("mineral", GeyserLootTable.categorize(Material.IRON_ORE));
+        assertEquals("mineral", GeyserLootTable.categorize(Material.RAW_COPPER));
+        assertEquals("mineral", GeyserLootTable.categorize(Material.GOLD_INGOT));
+        assertEquals("mineral", GeyserLootTable.categorize(Material.STONE));
+        assertEquals("mineral", GeyserLootTable.categorize(Material.COAL));
+    }
+
+    @Test
+    void testCategorizeForestry() {
+        assertEquals("forestry", GeyserLootTable.categorize(Material.OAK_LOG));
+        assertEquals("forestry", GeyserLootTable.categorize(Material.SPRUCE_PLANKS));
+        assertEquals("forestry", GeyserLootTable.categorize(Material.BAMBOO));
+        assertEquals("forestry", GeyserLootTable.categorize(Material.KELP));
+    }
+
+    @Test
+    void testCategorizeHusbandry() {
+        assertEquals("husbandry", GeyserLootTable.categorize(Material.WHITE_WOOL));
+        assertEquals("husbandry", GeyserLootTable.categorize(Material.LEATHER));
+        assertEquals("husbandry", GeyserLootTable.categorize(Material.STRING));
+        assertEquals("husbandry", GeyserLootTable.categorize(Material.COOKED_COD));
+    }
+
+    @Test
+    void testCategorizeNone() {
+        assertNull(GeyserLootTable.categorize(Material.TNT));
+        assertNull(GeyserLootTable.categorize(Material.GLASS));
+        assertNull(GeyserLootTable.categorize(Material.DIRT));
+    }
+}

--- a/src/test/java/world/bentobox/acidisland/geysers/GeyserOfferingsTaskTest.java
+++ b/src/test/java/world/bentobox/acidisland/geysers/GeyserOfferingsTaskTest.java
@@ -76,4 +76,11 @@ class GeyserOfferingsTaskTest {
         GeyserOfferingsTask task = new GeyserOfferingsTask(addon);
         assertDoesNotThrow(task::cancelTasks);
     }
+
+    @Test
+    void testOfferToVentWhenInert() {
+        // An inert task must refuse offers without touching the item
+        GeyserOfferingsTask task = new GeyserOfferingsTask(addon);
+        assertFalse(task.offerToVent(Mockito.mock(org.bukkit.entity.Item.class)));
+    }
 }

--- a/src/test/java/world/bentobox/acidisland/geysers/GeyserOfferingsTaskTest.java
+++ b/src/test/java/world/bentobox/acidisland/geysers/GeyserOfferingsTaskTest.java
@@ -31,7 +31,7 @@ import world.bentobox.acidisland.AcidIsland;
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class GeyserOfferingsTaskTest {
+class GeyserOfferingsTaskTest {
 
     @Mock
     private AcidIsland addon;

--- a/src/test/java/world/bentobox/acidisland/geysers/GeyserOfferingsTaskTest.java
+++ b/src/test/java/world/bentobox/acidisland/geysers/GeyserOfferingsTaskTest.java
@@ -1,0 +1,79 @@
+package world.bentobox.acidisland.geysers;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.bukkit.Bukkit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import world.bentobox.acidisland.AISettings;
+import world.bentobox.acidisland.AcidIsland;
+
+/**
+ * The offerings mechanic needs Minecraft 26.2's POTENT_SULFUR material, which
+ * does not exist on the 1.21 test classpath, so these tests cover the guard
+ * paths: the task must stay inert on unsupported servers and when disabled.
+ *
+ * @author tastybento
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class GeyserOfferingsTaskTest {
+
+    @Mock
+    private AcidIsland addon;
+
+    private AISettings settings;
+    private ServerMock server;
+    private MockedStatic<Bukkit> mockedBukkit;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        mockedBukkit = Mockito.mockStatic(Bukkit.class, Mockito.RETURNS_DEEP_STUBS);
+        mockedBukkit.when(Bukkit::getMinecraftVersion).thenReturn("1.21.11");
+        mockedBukkit.when(Bukkit::getServer).thenReturn(server);
+        settings = new AISettings();
+        when(addon.getSettings()).thenReturn(settings);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedBukkit.closeOnDemand();
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void testInertWithoutPotentSulfur() {
+        // Enabled in config, but the material does not exist on this server
+        GeyserOfferingsTask task = new GeyserOfferingsTask(addon);
+        assertFalse(task.isRunning());
+        assertTrue(task.getVents().isEmpty());
+    }
+
+    @Test
+    void testInertWhenDisabled() {
+        settings.setGeyserOfferings(false);
+        GeyserOfferingsTask task = new GeyserOfferingsTask(addon);
+        assertFalse(task.isRunning());
+    }
+
+    @Test
+    void testCancelTasksWhenNeverScheduled() {
+        GeyserOfferingsTask task = new GeyserOfferingsTask(addon);
+        assertDoesNotThrow(task::cancelTasks);
+    }
+}


### PR DESCRIPTION
Release 2.1.0

## What's in this release

- **Geyser offerings** ([PR #178](https://github.com/BentoBoxWorld/AcidIsland/pull/178)): items thrown into the water around a sulfur vent are consumed as offerings and transmuted into rewards spewed out with the vent's next eruption. Weighted `geyser-loot.yml` reward table with channel bias, new `world.geyser-offerings` config section, and new `GeyserSacrificeEvent`/`GeyserTransmuteEvent` API events. Requires Minecraft 26.2+; inert on older servers.
- CI: pinned publish-platforms.yml bumped to 8385477 (curl -F multipart fix)

Draft release notes: to be attached to the 2.1.0 draft release for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZvWEiRd9SePSigryf11Bh