### PR TITLE
Release 2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,44 @@ You're on an island, in a sea of acid! If you like Skyblock, try the AcidIsland�
 
 Instead of falling you must contend with acid water when expanding your island, and players can boat to each other's islands.
 
+## Features
+
+### The acid sea
+* The ocean damages players, mobs and items. Damage amounts, potion effects and the delay before burning are all configurable.
+* Acid rain (and optionally acid snow) burns players caught in the open.
+* Armour can protect: a helmet against rain, a full set against the acid itself — both off by default.
+* Boats are the way between islands, so the sea is a road as well as a hazard.
+
+### Purified water
+Water drawn from the acid sea hurts to drink. Clean water has to be made:
+* Collect rain in a cauldron fed by a dripstone stalactite.
+* Smelt a water bottle — or a water bucket — in a furnace.
+* Brew water bottles with coal in a brewing stand.
+
+Drinking purified water heals instead of harming. The whole mechanic, the heal amount, and whether it runs in the Nether and the End can be configured.
+
+### Sulfur seas (Minecraft 26.2 and later)
+On servers new enough to have them, AcidIsland uses the game's own toxic water:
+* The ocean is sulfur pool water in the `SULFUR_CAVES` biome — acid-green water under green fog.
+* Sulfur vents generate below the surface, bubbling and gassing before they erupt as geysers.
+* The ocean floor is varied terrain rather than a flat plain, and vanilla structures such as trial chambers generate buried beneath it, so there is a reason to dig down.
+* A "Sulfur Spring Refuge" starter island is included alongside the classic ones.
+
+Older servers fall back to normal water and a warm ocean biome — nothing breaks.
+
+### Geyser offerings (Minecraft 26.2 and later)
+Throw items into the water around a sulfur vent and it swallows them with a hiss. Items floating nearby drift in on their own, so a throw does not have to be accurate. A few seconds later the vent erupts and pays you back:
+
+* **It transmutes rather than destroys.** A vent works out what your offering was worth and hands back rewards worth about the same, so a diamond comes back in gems and a stack of cobble comes back in cobble-grade tat.
+* **What you feed it steers what it gives.** Offerings pull the reward table towards their own channel — gems, nether, mineral, forestry or husbandry — in proportion to the worth that went in.
+* **Named transmutations are worth learning.** Magma blocks make obsidian, iron makes gold, and bones with gunpowder make music discs — a way to get records without a mob farm.
+* Items the acid destroys inside a vent's pool count as offerings instead of being lost.
+
+Rewards live in `geyser-loot.yml` and item worth in `geyser-values.yml`, both created in the addon's data folder. Worth can defer to the Level addon's block values where the file is silent. Payout size, the exchange rate the vent trades at, the ceiling on any single reward, and whether feeding a vent provokes an early eruption are all configurable. `GeyserSacrificeEvent` and `GeyserTransmuteEvent` let other plugins watch or change what happens.
+
+### The usual BentoBox toolkit
+Teams with ranks and permissions, a large set of island protection flags, custom island blueprints, and compatibility with the whole family of BentoBox addons.
+
 ## Download
 
 You can download from GitHub, or ready made plugin packs from [https://download.bentobox.world](https://download.bentobox.world).

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>2.1.0</build.version>
+        <build.version>2.1.1</build.version>
         <!-- Sonar Cloud -->
         <sonar.projectKey>BentoBoxWorld_AcidIsland</sonar.projectKey>
         <sonar.organization>bentobox-world</sonar.organization>

--- a/src/main/java/world/bentobox/acidisland/AISettings.java
+++ b/src/main/java/world/bentobox/acidisland/AISettings.java
@@ -284,6 +284,35 @@ public class AISettings implements WorldSettings {
     @ConfigEntry(path = "world.geyser-offerings.max-rewards")
     private int geyserMaxRewards = 12;
 
+    @ConfigComment("Answer an offering with rewards of roughly the same worth, instead of one")
+    @ConfigComment("random reward per item. A vent transmutes rather than destroys: feed it a")
+    @ConfigComment("diamond and it owes a diamond's worth back, feed it cobble and it owes")
+    @ConfigComment("cobble. Worth comes from geyser-values.yml, which can defer to the Level")
+    @ConfigComment("addon's block values. Turn this off for the old one-roll-per-item payout.")
+    @ConfigEntry(path = "world.geyser-offerings.match-value")
+    private boolean geyserMatchValue = true;
+
+    @ConfigComment("Fraction of the offered worth a vent pays back when matching worth.")
+    @ConfigComment("1.0 is a fair trade, below 1.0 makes the vent take a cut, above 1.0 makes")
+    @ConfigComment("offering profitable in itself - which players will farm, so raise with care.")
+    @ConfigEntry(path = "world.geyser-offerings.exchange-rate")
+    private double geyserExchangeRate = 1.0;
+
+    @ConfigComment("The most a single reward may be worth, as a multiple of the worth of the")
+    @ConfigComment("richest item offered. A stack of cobble is worth an emerald and a cobble")
+    @ConfigComment("generator is infinite, so without this a vent becomes a gem printer. Rewards")
+    @ConfigComment("named in a from: list in geyser-loot.yml ignore this - a transmutation the")
+    @ConfigComment("admin has written down is always allowed. Set to 0 for no limit.")
+    @ConfigEntry(path = "world.geyser-offerings.reward-ceiling")
+    private double geyserRewardCeiling = 8.0;
+
+    @ConfigComment("Provoke a fed vent into erupting a few seconds after it is fed, instead of")
+    @ConfigComment("waiting for the vanilla eruption cycle, so the reward follows the offering")
+    @ConfigComment("while the player is still there to see it. Turn this off to leave eruption")
+    @ConfigComment("timing entirely to vanilla - offerings are then held until the vent erupts.")
+    @ConfigEntry(path = "world.geyser-offerings.erupt-on-offering")
+    private boolean geyserEruptOnOffering = true;
+
     @ConfigComment("Structures")
     @ConfigComment("This creates an vanilla structures in the worlds.")
     @ConfigComment("Trial chambers and other underground structures generate buried")
@@ -2210,6 +2239,62 @@ public class AISettings implements WorldSettings {
      */
     public void setGeyserMaxRewards(int geyserMaxRewards) {
         this.geyserMaxRewards = geyserMaxRewards;
+    }
+
+    /**
+     * @return true if rewards are matched to the worth of the offering
+     */
+    public boolean isGeyserMatchValue() {
+        return geyserMatchValue;
+    }
+
+    /**
+     * @param geyserMatchValue the geyserMatchValue to set
+     */
+    public void setGeyserMatchValue(boolean geyserMatchValue) {
+        this.geyserMatchValue = geyserMatchValue;
+    }
+
+    /**
+     * @return the fraction of the offered worth a vent pays back
+     */
+    public double getGeyserExchangeRate() {
+        return geyserExchangeRate;
+    }
+
+    /**
+     * @param geyserExchangeRate the geyserExchangeRate to set
+     */
+    public void setGeyserExchangeRate(double geyserExchangeRate) {
+        this.geyserExchangeRate = geyserExchangeRate;
+    }
+
+    /**
+     * @return the most a single reward may be worth, as a multiple of the richest item offered
+     */
+    public double getGeyserRewardCeiling() {
+        return geyserRewardCeiling;
+    }
+
+    /**
+     * @param geyserRewardCeiling the geyserRewardCeiling to set
+     */
+    public void setGeyserRewardCeiling(double geyserRewardCeiling) {
+        this.geyserRewardCeiling = geyserRewardCeiling;
+    }
+
+    /**
+     * @return true if a fed vent is provoked into erupting instead of waiting for the vanilla cycle
+     */
+    public boolean isGeyserEruptOnOffering() {
+        return geyserEruptOnOffering;
+    }
+
+    /**
+     * @param geyserEruptOnOffering the geyserEruptOnOffering to set
+     */
+    public void setGeyserEruptOnOffering(boolean geyserEruptOnOffering) {
+        this.geyserEruptOnOffering = geyserEruptOnOffering;
     }
 
     /**

--- a/src/main/java/world/bentobox/acidisland/geysers/GeyserLootEntry.java
+++ b/src/main/java/world/bentobox/acidisland/geysers/GeyserLootEntry.java
@@ -1,8 +1,11 @@
 package world.bentobox.acidisland.geysers;
 
+import java.util.EnumSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -18,12 +21,31 @@ import org.eclipse.jdt.annotation.Nullable;
  * @param channel the offering channel this entry belongs to, or null
  * @param min minimum amount
  * @param max maximum amount
+ * @param value what one of this reward costs the vent, or null to use the
+ * material's worth from geyser-values.yml
+ * @param from materials that transmute into this reward - offering any of them
+ * makes this entry far more likely
  *
  * @author tastybento
  * @since 2.1.0
  */
 public record GeyserLootEntry(@Nullable Material material, @Nullable String command, int weight,
-        @Nullable String channel, int min, int max) {
+        @Nullable String channel, int min, int max, @Nullable Integer value, Set<Material> from) {
+
+    /**
+     * An entry with no explicit value and no transmutation materials.
+     *
+     * @param material the material, or null for command entries
+     * @param command the console command, or null for item entries
+     * @param weight the base weight
+     * @param channel the offering channel this entry belongs to, or null
+     * @param min minimum amount
+     * @param max maximum amount
+     */
+    public GeyserLootEntry(@Nullable Material material, @Nullable String command, int weight, @Nullable String channel,
+            int min, int max) {
+        this(material, command, weight, channel, min, max, null, Set.of());
+    }
 
     /**
      * @return true if this is a command reward rather than an item
@@ -33,13 +55,29 @@ public record GeyserLootEntry(@Nullable Material material, @Nullable String comm
     }
 
     /**
+     * @param random random source
+     * @return a random amount in [min, max]
+     */
+    public int rollAmount(Random random) {
+        int amount = min >= max ? min : min + random.nextInt(max - min + 1);
+        return Math.max(1, amount);
+    }
+
+    /**
      * Roll an item stack from this entry.
      *
      * @param random random source
      * @return stack with a random amount in [min, max]
      */
     public ItemStack toItemStack(Random random) {
-        int amount = min >= max ? min : min + random.nextInt(max - min + 1);
+        return toItemStack(rollAmount(random));
+    }
+
+    /**
+     * @param amount how many to give
+     * @return a stack of this entry's material
+     */
+    public ItemStack toItemStack(int amount) {
         return new ItemStack(material, Math.max(1, amount));
     }
 
@@ -55,6 +93,8 @@ public record GeyserLootEntry(@Nullable Material material, @Nullable String comm
     public static GeyserLootEntry parse(Map<?, ?> map) {
         int weight = map.get("weight") instanceof Number n ? n.intValue() : 1;
         String channel = map.get("channel") instanceof String s ? s.toLowerCase(Locale.ROOT) : null;
+        Integer value = map.get("value") instanceof Number n ? n.intValue() : null;
+        Set<Material> from = parseFrom(map.get("from"));
         int min = 1;
         int max = 1;
         if (map.get("amount") instanceof Map<?, ?> amount) {
@@ -65,14 +105,36 @@ public record GeyserLootEntry(@Nullable Material material, @Nullable String comm
             max = n.intValue();
         }
         if (map.get("command") instanceof String command && !command.isBlank()) {
-            return new GeyserLootEntry(null, command, weight, channel, min, max);
+            return new GeyserLootEntry(null, command, weight, channel, min, max, value, from);
         }
         if (map.get("item") instanceof String item) {
             Material material = Material.matchMaterial(item);
             if (material != null) {
-                return new GeyserLootEntry(material, null, weight, channel, min, max);
+                return new GeyserLootEntry(material, null, weight, channel, min, max, value, from);
             }
         }
         return null;
+    }
+
+    /**
+     * Parse the optional {@code from:} list of materials that transmute into
+     * this reward. Unknown materials are skipped, so a table may name materials
+     * from a newer Minecraft version than the server runs.
+     *
+     * @param raw the raw value from the YAML map
+     * @return the materials, empty if there are none
+     */
+    private static Set<Material> parseFrom(@Nullable Object raw) {
+        if (!(raw instanceof List<?> list) || list.isEmpty()) {
+            return Set.of();
+        }
+        Set<Material> from = EnumSet.noneOf(Material.class);
+        for (Object o : list) {
+            Material material = o instanceof String s ? Material.matchMaterial(s) : null;
+            if (material != null) {
+                from.add(material);
+            }
+        }
+        return from;
     }
 }

--- a/src/main/java/world/bentobox/acidisland/geysers/GeyserLootTable.java
+++ b/src/main/java/world/bentobox/acidisland/geysers/GeyserLootTable.java
@@ -1,6 +1,7 @@
 package world.bentobox.acidisland.geysers;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -13,17 +14,43 @@ import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * The weighted geyser reward table, loaded from {@code geyser-loot.yml}.
- * Entries with a channel are boosted by the offerings sacrificed to the vent:
+ * Entries with a channel are boosted by the share of the offering's worth that
+ * went into that channel:
  * <pre>
- * effective = weight × (1 + 0.5 × offeringPoints(entry.channel))
+ * effective = weight × (1 + 3 × channelWorth / totalChannelWorth)
  * </pre>
- * so a vent fed diamonds leans towards gems, a vent fed logs towards forestry,
- * and so on.
+ * so a vent fed nothing but diamonds leans hard towards gems, a vent fed logs
+ * towards forestry, and a vent fed a bit of everything leans nowhere. Worth
+ * rather than item count is what pulls, so one diamond steers the table as
+ * firmly as the stack of cobble it is worth.
+ * <p>
+ * An entry that names the offered material in its {@code from:} list
+ * is a direct transmutation - magma into obsidian - and is boosted far harder,
+ * so feeding a vent a specific thing reliably yields the thing it makes.
+ * <p>
+ * When the payout is budgeted by worth, entries the vent cannot afford are not
+ * rolled at all, and entries worth a pittance next to the budget are damped, so
+ * a diamond is answered in gems rather than in a heap of kelp.
  *
  * @author tastybento
  * @since 2.1.0
  */
 public class GeyserLootTable {
+
+    /**
+     * How hard the channel a vent was fed pulls the table towards itself: an
+     * entry whose channel took the whole offering is this much more likely.
+     */
+    private static final double CHANNEL_PULL = 3;
+    /** Weight multiplier for an entry that directly transmutes an offered material. */
+    private static final double RECIPE_BOOST = 8;
+    /**
+     * An entry worth less than this fraction of the budget is damped, so big
+     * offerings are answered with big rewards.
+     */
+    private static final double PITTANCE_FRACTION = 0.125;
+    /** Weight multiplier applied to entries worth a pittance next to the budget. */
+    private static final double PITTANCE_DAMPING = 0.25;
 
     private final List<GeyserLootEntry> loot;
 
@@ -65,7 +92,81 @@ public class GeyserLootTable {
     }
 
     /**
-     * Weighted roll honoring the vent's offering bias.
+     * One reward a vent has decided to hand over.
+     *
+     * @param entry the entry rolled
+     * @param amount how many to give - ignored for command entries
+     */
+    public record Award(GeyserLootEntry entry, int amount) {
+    }
+
+    /**
+     * Work out everything a vent hands over for one eruption.
+     * <p>
+     * When the offer has a budget, the vent keeps rolling rewards it can still
+     * afford and subtracting their worth until the worth it owes is spent, so
+     * the payout is worth about what was fed in. Its final roll gives as many
+     * as the leftover worth allows rather than pocketing the remainder.
+     * Otherwise it simply rolls {@code maxRewards} times.
+     *
+     * @param random random source
+     * @param offer what the vent was fed and owes
+     * @param values worth of materials, or null if worth is not being matched
+     * @param maxRewards hard cap on how many rewards may be handed over
+     * @return the rewards to hand over, in the order they were rolled
+     */
+    @NonNull
+    public List<Award> plan(Random random, @NonNull GeyserOffer offer, @Nullable GeyserValues values, int maxRewards) {
+        boolean budgeted = offer.isBudgeted() && values != null;
+        int budget = offer.budget();
+        int rolls = Math.max(1, maxRewards);
+        List<Award> awards = new ArrayList<>();
+        for (int paid = 0; paid < rolls; paid++) {
+            boolean last = paid == rolls - 1;
+            GeyserOffer current = budgeted
+                    ? new GeyserOffer(offer.bias(), offer.materials(), budget, offer.ceiling())
+                    : offer;
+            // On the last roll, first look for something that can soak up what
+            // is left; if nothing can, take whatever the table offers
+            GeyserLootEntry entry = last ? roll(random, current, budgeted ? values : null, true) : null;
+            if (entry == null) {
+                entry = roll(random, current, budgeted ? values : null, false);
+            }
+            if (entry == null) {
+                // Nothing left in the table the vent can afford
+                break;
+            }
+            int amount = amountFor(entry, values, budget, budgeted, last, random);
+            awards.add(new Award(entry, amount));
+            if (budgeted) {
+                budget -= values.unitValue(entry) * (entry.isCommand() ? 1 : amount);
+                if (budget <= 0) {
+                    break;
+                }
+            }
+        }
+        return awards;
+    }
+
+    /**
+     * How many of a reward to give: its own rolled amount, capped by what the
+     * vent can still afford and by the stack size. On the vent's last roll it
+     * gives as many as the budget allows, so leftover worth is paid out.
+     */
+    private int amountFor(GeyserLootEntry entry, @Nullable GeyserValues values, int budget, boolean budgeted,
+            boolean last, Random random) {
+        int rolled = entry.rollAmount(random);
+        if (!budgeted || entry.isCommand()) {
+            return rolled;
+        }
+        int unit = values.unitValue(entry);
+        int affordable = unit > 0 ? budget / unit : Integer.MAX_VALUE;
+        int cap = Math.max(1, Math.min(affordable, entry.material().getMaxStackSize()));
+        return last ? cap : Math.clamp(rolled, 1, cap);
+    }
+
+    /**
+     * Weighted roll honoring the vent's offering bias, with no worth budget.
      *
      * @param random random source
      * @param bias channel name to offering bias points
@@ -73,10 +174,40 @@ public class GeyserLootTable {
      */
     @Nullable
     public GeyserLootEntry roll(Random random, @NonNull Map<String, Integer> bias) {
+        return roll(random, GeyserOffer.of(bias), null);
+    }
+
+    /**
+     * Weighted roll honoring the vent's offering bias, its transmutations, and
+     * what worth it has left to pay out.
+     *
+     * @param random random source
+     * @param offer what the vent was fed and still owes
+     * @param values worth of materials, or null if worth is not being matched
+     * @return the rolled entry, or null if the table is empty or the vent can
+     * afford nothing in it
+     */
+    @Nullable
+    public GeyserLootEntry roll(Random random, @NonNull GeyserOffer offer, @Nullable GeyserValues values) {
+        return roll(random, offer, values, false);
+    }
+
+    /**
+     * Weighted roll, optionally as the vent's final roll of an eruption.
+     *
+     * @param random random source
+     * @param offer what the vent was fed and still owes
+     * @param values worth of materials, or null if worth is not being matched
+     * @param lastRoll true to skip entries too cheap to spend the rest of the budget on
+     * @return the rolled entry, or null if nothing qualifies
+     */
+    @Nullable
+    private GeyserLootEntry roll(Random random, @NonNull GeyserOffer offer, @Nullable GeyserValues values,
+            boolean lastRoll) {
         double total = 0;
         double[] weights = new double[loot.size()];
         for (int i = 0; i < loot.size(); i++) {
-            weights[i] = effectiveWeight(loot.get(i), bias);
+            weights[i] = effectiveWeight(loot.get(i), offer, values, lastRoll);
             total += weights[i];
         }
         if (total <= 0) {
@@ -96,11 +227,78 @@ public class GeyserLootTable {
      * Effective weight of one entry given the vent's offering bias.
      */
     double effectiveWeight(GeyserLootEntry entry, @NonNull Map<String, Integer> bias) {
-        double weight = entry.weight();
-        if (entry.channel() != null) {
-            weight *= 1 + 0.5 * bias.getOrDefault(entry.channel(), 0);
+        return effectiveWeight(entry, GeyserOffer.of(bias), null);
+    }
+
+    /**
+     * Effective weight of one entry given what the vent was fed and can afford.
+     */
+    double effectiveWeight(GeyserLootEntry entry, @NonNull GeyserOffer offer, @Nullable GeyserValues values) {
+        return effectiveWeight(entry, offer, values, false);
+    }
+
+    /**
+     * Effective weight of one entry given what the vent was fed and can afford.
+     * An entry the vent cannot pay for, or that is far richer than anything it
+     * was fed, weighs nothing and is never rolled.
+     *
+     * @param entry the entry
+     * @param offer what the vent was fed and owes
+     * @param values worth of materials, or null if worth is not being matched
+     * @param lastRoll true if this is the vent's final roll, where entries too
+     * cheap to spend the remaining worth on are skipped rather than leaving it
+     * unpaid
+     */
+    double effectiveWeight(GeyserLootEntry entry, @NonNull GeyserOffer offer, @Nullable GeyserValues values,
+            boolean lastRoll) {
+        double weight = entry.weight() * channelPull(entry, offer);
+        boolean transmutes = !entry.from().isEmpty() && !Collections.disjoint(entry.from(), offer.materials());
+        if (transmutes) {
+            weight *= RECIPE_BOOST;
+        }
+        if (values == null || !offer.isBudgeted()) {
+            return weight;
+        }
+        int cost = values.unitValue(entry);
+        if (cost > offer.budget()) {
+            return 0;
+        }
+        // A named transmutation may be as rich as the admin likes; anything
+        // else has to stay in the league of what was thrown in
+        if (!transmutes && offer.hasCeiling() && cost > offer.ceiling()) {
+            return 0;
+        }
+        if (lastRoll && cost > 0 && cost * stackSize(entry) < offer.budget()) {
+            // Too cheap to spend what is left, even a full stack of it
+            return 0;
+        }
+        if (cost > 0 && cost < offer.budget() * PITTANCE_FRACTION) {
+            weight *= PITTANCE_DAMPING;
         }
         return weight;
+    }
+
+    /**
+     * @return how much the vent's offering pulls the table towards this entry's
+     * channel, from 1 (nothing of that channel was fed in) up to
+     * 1 + {@link #CHANNEL_PULL} (the offering was nothing else)
+     */
+    private static double channelPull(GeyserLootEntry entry, @NonNull GeyserOffer offer) {
+        if (entry.channel() == null || offer.bias().isEmpty()) {
+            return 1;
+        }
+        double total = 0;
+        for (int points : offer.bias().values()) {
+            total += points;
+        }
+        if (total <= 0) {
+            return 1;
+        }
+        return 1 + CHANNEL_PULL * (offer.bias().getOrDefault(entry.channel(), 0) / total);
+    }
+
+    private static int stackSize(GeyserLootEntry entry) {
+        return entry.material() == null ? 1 : entry.material().getMaxStackSize();
     }
 
     /**

--- a/src/main/java/world/bentobox/acidisland/geysers/GeyserOffer.java
+++ b/src/main/java/world/bentobox/acidisland/geysers/GeyserOffer.java
@@ -1,0 +1,64 @@
+package world.bentobox.acidisland.geysers;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.bukkit.Material;
+
+/**
+ * What a vent has been fed, as the reward table sees it: which channels the
+ * offerings lean towards, the actual materials that went in, and how much worth
+ * the vent still owes.
+ *
+ * @param bias channel name to offering points
+ * @param materials the materials offered, for {@code from:} transmutations
+ * @param budget the worth left to pay out, or {@link #UNLIMITED} to ignore worth
+ * @param ceiling the most a single reward may be worth, or {@link #NO_CEILING}.
+ * Total worth alone is not enough: a stack of cobble is worth an emerald, and a
+ * cobble generator is infinite, so a vent will not hand back anything far richer
+ * than the richest thing it was fed. Entries with a matching {@code from:} list
+ * ignore the ceiling - a named transmutation is the admin saying it is allowed.
+ *
+ * @author tastybento
+ * @since 2.1.1
+ */
+public record GeyserOffer(Map<String, Integer> bias, Set<Material> materials, int budget, int ceiling) {
+
+    /** Budget value meaning "pay out whatever, worth is not being matched". */
+    public static final int UNLIMITED = -1;
+    /** Ceiling value meaning "any single reward is allowed, however rich". */
+    public static final int NO_CEILING = -1;
+
+    /**
+     * An offer with no limit on what a single reward may be worth.
+     *
+     * @param bias channel name to offering points
+     * @param materials the materials offered
+     * @param budget the worth left to pay out
+     */
+    public GeyserOffer(Map<String, Integer> bias, Set<Material> materials, int budget) {
+        this(bias, materials, budget, NO_CEILING);
+    }
+
+    /**
+     * @param bias channel name to offering points
+     * @return an offer with no material transmutations, budget or ceiling
+     */
+    public static GeyserOffer of(Map<String, Integer> bias) {
+        return new GeyserOffer(bias, Set.of(), UNLIMITED, NO_CEILING);
+    }
+
+    /**
+     * @return true if rewards must be paid within a worth budget
+     */
+    public boolean isBudgeted() {
+        return budget != UNLIMITED;
+    }
+
+    /**
+     * @return true if there is a limit on what a single reward may be worth
+     */
+    public boolean hasCeiling() {
+        return ceiling != NO_CEILING;
+    }
+}

--- a/src/main/java/world/bentobox/acidisland/geysers/GeyserOfferingsTask.java
+++ b/src/main/java/world/bentobox/acidisland/geysers/GeyserOfferingsTask.java
@@ -2,12 +2,16 @@ package world.bentobox.acidisland.geysers;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -21,6 +25,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.Vector;
@@ -29,19 +34,27 @@ import org.eclipse.jdt.annotation.Nullable;
 import world.bentobox.acidisland.AcidIsland;
 import world.bentobox.acidisland.events.GeyserSacrificeEvent;
 import world.bentobox.acidisland.events.GeyserTransmuteEvent;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.util.Util;
 
 /**
- * The geyser offerings mechanic: items thrown into the water around a sulfur
- * vent are consumed with a sizzle as offerings, and when the vent's vanilla
- * geyser next erupts, the offerings are transmuted into rewards spewed out of
- * the plume. Rewards are rolled from the weighted {@code geyser-loot.yml}
- * table, biased towards the channels of the materials sacrificed.
+ * The geyser offerings mechanic: items a player throws into the water around a
+ * sulfur vent are consumed with a sizzle as offerings, and when the vent erupts
+ * the offerings are transmuted into rewards spewed out of the plume. Rewards are
+ * rolled from the weighted {@code geyser-loot.yml} table, biased towards the
+ * channels of the materials sacrificed, and worth about what was fed in: the
+ * vent transmutes rather than destroys.
  * <p>
- * Eruptions are driven entirely by vanilla (Minecraft 26.2+ potent sulfur), so
- * a once-a-second task watches fed vents for the block's
- * {@code potent_sulfur_state} to pass through {@code erupting}; the rewards pay
- * out as the plume settles so the eruption itself cannot fling them away. On
- * older servers the mechanic is inert.
+ * A once-a-second task drives the whole loop. Items floating anywhere near a
+ * vent are tugged towards it so a throw does not have to be accurate - the
+ * drift is also the only cue a player gets that a vent eats items. A fed vent
+ * is then provoked into erupting a few seconds later, so the reward follows the
+ * offering while the player is still watching, and the payout lands as the
+ * plume settles so the eruption cannot fling it away.
+ * <p>
+ * All sulfur handling is string-based because the addon compiles against Paper
+ * 1.21: on servers older than Minecraft 26.2 the material does not exist and
+ * the mechanic is inert.
  *
  * @author tastybento
  * @since 2.1.0
@@ -65,8 +78,28 @@ public class GeyserOfferingsTask {
      * land - anywhere in the pool around the vent counts instead.
      */
     private static final int POOL_SCAN_RADIUS = 3;
+    /** Horizontal radius within which a vent tugs a floating item towards itself. */
+    private static final int SUCTION_RADIUS = 5;
+    /** How far below a floating item a vent can be and still tug it in. */
+    private static final int SUCTION_DEPTH = 6;
+    /** Velocity impulse applied once a second to an item being tugged in. */
+    private static final double SUCTION_PULL = 0.15;
+    /** How far below an item to probe for water before bothering with a suction scan. */
+    private static final int WATER_PROBE_DEPTH = 3;
+    /**
+     * Seconds a fed vent waits before it is provoked into erupting. A thrown
+     * stack lands as several items, so this batches them into one eruption.
+     */
+    private static final int PROVOKE_DELAY = 3;
+    /**
+     * Seconds a vent may stay erupting before its rewards are paid out anyway,
+     * so offerings are never held forever by a plume that does not settle.
+     */
+    private static final int ERUPTION_TIMEOUT = 30;
     /** Radius around the plume to look for a player to run command rewards for. */
     private static final double COMMAND_RANGE_SQUARED = 24.0 * 24;
+    /** Radius around a vent within which its feeders are told what it is doing. */
+    private static final double MESSAGE_RANGE_SQUARED = 48.0 * 48;
 
     /**
      * PDC tag on spewed reward items. Tagged items are never consumed as
@@ -80,16 +113,31 @@ public class GeyserOfferingsTask {
 
     /**
      * Offerings pending at one vent: reward channel bias, the number of items
-     * sacrificed, and the eruption state seen last tick.
+     * sacrificed, who fed it, and where the vent is in its eruption cycle.
      */
     static class VentOfferings {
         final Map<String, Integer> bias = new HashMap<>();
+        /** Players who fed this vent, so they can be told when it answers. */
+        final Set<UUID> contributors = new HashSet<>();
+        /** Materials fed to this vent, for {@code from:} transmutations in the loot table. */
+        final Set<Material> materials = EnumSet.noneOf(Material.class);
         int items;
+        /** Total worth of everything fed to this vent, which is what it owes back. */
+        int value;
+        /** Worth of the richest single item fed in, which caps how rich a reward may be. */
+        int topValue;
         boolean erupting;
+        /** Seconds since the first offering, used to batch a thrown stack before provoking. */
+        int age;
+        /** Seconds the vent has been erupting, so a plume that sticks still pays out. */
+        int eruptingFor;
+        /** True once this vent has been provoked, so it is only ever provoked once. */
+        boolean provoked;
     }
 
     private final AcidIsland addon;
     private final @Nullable GeyserLootTable table;
+    private final @Nullable GeyserValues values;
     private final @Nullable BukkitTask task;
     private final Map<Vector, VentOfferings> vents = new HashMap<>();
 
@@ -104,21 +152,25 @@ public class GeyserOfferingsTask {
         this.addon = addon;
         if (!addon.getSettings().isGeyserOfferings()) {
             table = null;
+            values = null;
             task = null;
             return;
         }
         if (POTENT_SULFUR == null) {
             addon.log("Geyser offerings require Minecraft 26.2 or later - mechanic disabled.");
             table = null;
+            values = null;
             task = null;
             return;
         }
         table = loadTable();
         if (table.isEmpty()) {
             addon.logError("geyser-loot.yml has no valid loot entries - geyser offerings disabled.");
+            values = null;
             task = null;
             return;
         }
+        values = new GeyserValues(addon);
         task = Bukkit.getScheduler().runTaskTimer(addon.getPlugin(), this::tick, 20L, 20L);
         addon.log("Geyser offerings active: " + table.getLoot().size() + " loot entries, max "
                 + addon.getSettings().getGeyserMaxRewards() + " rewards per eruption.");
@@ -172,16 +224,20 @@ public class GeyserOfferingsTask {
     }
 
     /**
-     * Consume items floating in the water around a vent cap as offerings.
+     * Consume items floating in the water around a vent cap as offerings, and
+     * tug the ones that are close but not close enough into the pool.
      */
     private void consumeOfferings(World world) {
         for (Item item : world.getEntitiesByClass(Item.class)) {
-            if (item.getTicksLived() >= MIN_AGE_TICKS && !isReward(item)) {
-                Block start = waterStart(item);
-                Block vent = start == null ? null : findVentNear(start);
-                if (vent != null) {
-                    sacrifice(world, item, vent);
-                }
+            if (!canSacrifice(item)) {
+                continue;
+            }
+            Block start = waterStart(item);
+            Block vent = start == null ? null : findVentNear(start);
+            if (vent != null) {
+                sacrifice(world, item, vent);
+            } else {
+                tugTowardsVent(item);
             }
         }
     }
@@ -194,6 +250,62 @@ public class GeyserOfferingsTask {
     }
 
     /**
+     * @return true if the item may be offered at all. Only items a player threw
+     * count: death drops, block drops and mob drops have no thrower and are left
+     * alone, so a vent cannot quietly eat an inventory that washes into its pool.
+     * Rewards the vent just spewed are excluded too, which stops them being
+     * recycled into fresh offerings.
+     */
+    static boolean isOffering(Item item) {
+        return !isReward(item) && item.getThrower() != null;
+    }
+
+    /**
+     * @return true if the item is an offering that has settled long enough to be
+     * consumed by the floating scan
+     */
+    private static boolean canSacrifice(Item item) {
+        return item.getTicksLived() >= MIN_AGE_TICKS && isOffering(item);
+    }
+
+    /**
+     * Tug an item floating near a vent towards its pool. Items bob, drift, and
+     * get lofted clear of the water by the vent's own bubble column, so without
+     * this a player whose throw landed a block or two out just watches it sit
+     * there with no hint of what went wrong. The visible drift towards the vent
+     * is also the only cue that a vent eats items at all.
+     */
+    private void tugTowardsVent(Item item) {
+        Block block = item.getLocation().getBlock();
+        if (!nearWater(block)) {
+            return;
+        }
+        Block vent = findVent(block, SUCTION_RADIUS, 0, SUCTION_DEPTH);
+        if (vent == null) {
+            return;
+        }
+        // Aim at the water just above the cap rather than into the block itself
+        Vector pull = vent.getLocation().add(0.5, 1, 0.5).toVector().subtract(item.getLocation().toVector());
+        double distance = pull.length();
+        if (distance > 0.1) {
+            item.setVelocity(item.getVelocity().add(pull.multiply(SUCTION_PULL / distance)));
+        }
+    }
+
+    /**
+     * @return true if there is water at or just below the block, so an item
+     * there is worth scanning for a nearby vent
+     */
+    private static boolean nearWater(Block block) {
+        for (int dy = 0; dy <= WATER_PROBE_DEPTH; dy++) {
+            if (isWaterLike(block.getRelative(0, -dy, 0).getType())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Offer an item to a nearby vent on behalf of another consumer. Called by
      * {@link world.bentobox.acidisland.world.AcidTask} when acid is about to
      * destroy a floating item, so acid destruction within a vent's pool counts
@@ -203,7 +315,7 @@ public class GeyserOfferingsTask {
      * @return true if a vent consumed the item as an offering
      */
     public boolean offerToVent(Item item) {
-        if (task == null || isReward(item)) {
+        if (task == null || !isOffering(item)) {
             return false;
         }
         Block start = waterStart(item);
@@ -213,15 +325,29 @@ public class GeyserOfferingsTask {
 
     /**
      * Look for a potent sulfur cap in the pool below and around a floating
-     * item. Scans shallowest layer first so a twin vent's main cap wins.
+     * item.
      *
      * @param start the water block the floating item is in
-     * @return the nearest vent cap block, or null if the item is not near a vent
+     * @return the nearest vent cap block, or null if the item is not in a vent's pool
      */
     private @Nullable Block findVentNear(Block start) {
-        for (int dy = 1; dy <= POOL_SCAN_DEPTH; dy++) {
-            for (int dx = -POOL_SCAN_RADIUS; dx <= POOL_SCAN_RADIUS; dx++) {
-                for (int dz = -POOL_SCAN_RADIUS; dz <= POOL_SCAN_RADIUS; dz++) {
+        return findVent(start, POOL_SCAN_RADIUS, 1, POOL_SCAN_DEPTH);
+    }
+
+    /**
+     * Look for a potent sulfur cap around and below a block. Scans the
+     * shallowest layer first so a twin vent's main cap wins.
+     *
+     * @param start block to scan from
+     * @param radius horizontal radius to scan
+     * @param fromDepth first layer to scan, in blocks below the start block
+     * @param toDepth last layer to scan, in blocks below the start block
+     * @return the nearest vent cap block, or null if there is none in range
+     */
+    private @Nullable Block findVent(Block start, int radius, int fromDepth, int toDepth) {
+        for (int dy = fromDepth; dy <= toDepth; dy++) {
+            for (int dx = -radius; dx <= radius; dx++) {
+                for (int dz = -radius; dz <= radius; dz++) {
                     Block block = start.getRelative(dx, -dy, dz);
                     if (block.getType() == POTENT_SULFUR) {
                         return block;
@@ -250,9 +376,20 @@ public class GeyserOfferingsTask {
             return v;
         });
         int amount = item.getItemStack().getAmount();
+        int worth = values.getValue(item.getItemStack());
         offerings.items += amount;
+        offerings.value += worth;
+        offerings.topValue = Math.max(offerings.topValue, values.getValue(item.getItemStack().getType()));
+        offerings.materials.add(item.getItemStack().getType());
         if (channel != null) {
-            offerings.bias.merge(channel, amount, Integer::sum);
+            // Worth, not item count, is what steers the payout: one diamond
+            // should pull as hard as the stack of cobble it is worth
+            offerings.bias.merge(channel, Math.max(1, worth), Integer::sum);
+        }
+        UUID thrower = item.getThrower();
+        if (thrower != null) {
+            offerings.contributors.add(thrower);
+            tellThrower(thrower, item.getItemStack().getType(), channel);
         }
         // Consumed either way - the geyser is not a storage unit
         item.remove();
@@ -262,9 +399,72 @@ public class GeyserOfferingsTask {
     }
 
     /**
-     * Watch fed vents: when a vent that was erupting settles again, spew the
-     * transmuted rewards. Vents that have been mined out forfeit their
-     * offerings.
+     * Tell the player whose offering was just swallowed what the vent took and,
+     * when the material has one, which reward channel it leans on. Naming the
+     * channel here is the only way a player discovers that what they feed a
+     * vent steers what it gives back.
+     */
+    private void tellThrower(UUID uuid, Material material, @Nullable String channel) {
+        Player player = Bukkit.getPlayer(uuid);
+        if (player == null) {
+            return;
+        }
+        User user = User.getInstance(player);
+        String item = Util.prettifyText(material.name());
+        if (channel == null) {
+            user.sendMessage("acidisland.geyser.offering", "[item]", item);
+        } else {
+            user.sendMessage("acidisland.geyser.offering-channel", "[item]", item, "[channel]",
+                    channelName(user, channel));
+        }
+    }
+
+    /**
+     * @return the translated name of a reward channel, falling back to the raw
+     * channel name so channels added to geyser-loot.yml still read sensibly
+     */
+    private static String channelName(User user, String channel) {
+        String name = user.getTranslationOrNothing("acidisland.geyser.channels." + channel);
+        return name.isEmpty() ? channel : name;
+    }
+
+    /**
+     * Tell the players who fed a vent what it is doing, if they are still near
+     * enough to see it happen.
+     *
+     * @param where the vent's plume
+     * @param offerings the vent's pending offerings
+     * @param reference locale reference
+     * @param channel channel to name in the message, or null if it takes none
+     */
+    private void announce(Location where, VentOfferings offerings, String reference, @Nullable String channel) {
+        for (UUID uuid : offerings.contributors) {
+            Player player = Bukkit.getPlayer(uuid);
+            if (player == null || !player.getWorld().equals(where.getWorld())
+                    || player.getLocation().distanceSquared(where) > MESSAGE_RANGE_SQUARED) {
+                continue;
+            }
+            User user = User.getInstance(player);
+            if (channel == null) {
+                user.sendMessage(reference);
+            } else {
+                user.sendMessage(reference, "[channel]", channelName(user, channel));
+            }
+        }
+    }
+
+    /**
+     * @return the channel the vent was fed most of, or null if nothing offered
+     * carried a channel
+     */
+    static @Nullable String dominantChannel(VentOfferings offerings) {
+        return offerings.bias.entrySet().stream().max(Map.Entry.comparingByValue()).map(Map.Entry::getKey).orElse(null);
+    }
+
+    /**
+     * Watch fed vents: provoke them into erupting, and when a vent that was
+     * erupting settles again, spew the transmuted rewards. Vents that have been
+     * mined out forfeit their offerings.
      */
     private void watchVents(World world) {
         Iterator<Map.Entry<Vector, VentOfferings>> it = vents.entrySet().iterator();
@@ -293,6 +493,7 @@ public class GeyserOfferingsTask {
             // Mined out - offerings forfeited
             return true;
         }
+        offerings.age++;
         boolean erupting = isErupting(vent);
         if (offerings.erupting && !erupting) {
             // The plume has settled - pay out now so the eruption cannot
@@ -300,12 +501,53 @@ public class GeyserOfferingsTask {
             spew(world, vent, offerings);
             return true;
         }
+        if (erupting) {
+            offerings.eruptingFor++;
+            if (offerings.eruptingFor >= ERUPTION_TIMEOUT) {
+                // The plume never settled - unstick the vent and pay out rather
+                // than hold the offerings forever
+                vent.tick();
+                spew(world, vent, offerings);
+                return true;
+            }
+        } else if (!offerings.provoked && offerings.age >= PROVOKE_DELAY && provoke(vent, offerings)) {
+            // Treat it as erupting from here so the payout fires as the plume settles
+            offerings.erupting = true;
+            return false;
+        }
         offerings.erupting = erupting;
         return false;
     }
 
     private boolean isErupting(Block vent) {
         return vent.getBlockData().getAsString().contains(ERUPTING_STATE);
+    }
+
+    /**
+     * Provoke a fed vent into erupting now instead of waiting out the vanilla
+     * cycle. Without this the payout can arrive minutes after the offering,
+     * long after the player has sailed off, so nothing connects the two.
+     *
+     * @param vent the vent cap
+     * @param offerings the vent's pending offerings
+     * @return true if the vent was set erupting
+     */
+    private boolean provoke(Block vent, VentOfferings offerings) {
+        offerings.provoked = true;
+        if (!addon.getSettings().isGeyserEruptOnOffering()) {
+            return false;
+        }
+        String data = vent.getBlockData().getAsString().replaceAll("potent_sulfur_state=\\w+", ERUPTING_STATE);
+        try {
+            vent.setBlockData(Bukkit.createBlockData(data), true);
+        } catch (IllegalArgumentException e) {
+            // Unknown state on this server - leave the eruption to vanilla
+            addon.logWarning("Could not provoke a sulfur vent into erupting: " + e.getMessage());
+            return false;
+        }
+        vent.getWorld().playSound(vent.getLocation(), Sound.BLOCK_LAVA_AMBIENT, 1F, 0.6F);
+        announce(vent.getLocation(), offerings, "acidisland.geyser.churning", null);
+        return true;
     }
 
     /**
@@ -319,22 +561,59 @@ public class GeyserOfferingsTask {
             top = top.getRelative(BlockFace.UP);
         }
         Location spawn = top.getLocation().add(0.5, 0.5, 0.5);
-        int rolls = Math.clamp(offerings.items, 1, Math.max(1, addon.getSettings().getGeyserMaxRewards()));
-        List<Item> rewards = new ArrayList<>(rolls);
-        for (int i = 0; i < rolls; i++) {
-            GeyserLootEntry entry = table.roll(RAND, offerings.bias);
-            if (entry == null) {
-                break;
-            }
-            if (entry.isCommand()) {
-                executeReward(world, spawn, entry);
-            } else {
-                rewards.add(launchReward(world, spawn, entry));
-            }
-        }
+        List<Item> rewards = payOut(world, spawn, offerings);
         world.playSound(spawn, Sound.ENTITY_GENERIC_SPLASH, 1F, 1F);
         world.spawnParticle(Particle.SPLASH, spawn, 40, 0.4, 0.6, 0.4, 0.2);
+        String channel = dominantChannel(offerings);
+        announce(spawn, offerings, channel == null ? "acidisland.geyser.payout" : "acidisland.geyser.payout-channel",
+                channel);
         Bukkit.getPluginManager().callEvent(new GeyserTransmuteEvent(vent.getLocation(), rewards, offerings.items));
+    }
+
+    /**
+     * Roll and hand out a vent's rewards.
+     * <p>
+     * With worth matching on, the vent owes back what it was fed times the
+     * exchange rate, and keeps rolling rewards it can still afford until that
+     * worth is spent - so a diamond comes back as gems rather than as one
+     * random trinket, and a stack of cobble comes back as cobble-grade tat.
+     * Otherwise it falls back to one roll per item offered.
+     *
+     * @return the reward items spewed, which excludes command rewards
+     */
+    private List<Item> payOut(World world, Location spawn, VentOfferings offerings) {
+        int max = Math.max(1, addon.getSettings().getGeyserMaxRewards());
+        boolean budgeted = addon.getSettings().isGeyserMatchValue();
+        int budget = budgeted ? (int) Math.round(offerings.value * addon.getSettings().getGeyserExchangeRate())
+                : GeyserOffer.UNLIMITED;
+        int rolls = budgeted ? max : Math.clamp(offerings.items, 1, max);
+        GeyserOffer offer = new GeyserOffer(offerings.bias, offerings.materials, budget, ceiling(offerings));
+        List<Item> rewards = new ArrayList<>();
+        for (GeyserLootTable.Award award : table.plan(RAND, offer, budgeted ? values : null, rolls)) {
+            if (award.entry().isCommand()) {
+                executeReward(world, spawn, award.entry());
+            } else {
+                rewards.add(launchReward(world, spawn, award.entry().toItemStack(award.amount())));
+            }
+        }
+        return rewards;
+    }
+
+    /**
+     * The most a single reward may be worth: what the richest thing fed in was
+     * worth, times the configured multiplier. Without this a stack of cobble -
+     * worth an emerald, and infinite on an island with a generator - would buy
+     * gems. Named {@code from:} transmutations ignore it.
+     *
+     * @param offerings the vent's offerings
+     * @return the ceiling, or {@link GeyserOffer#NO_CEILING} if it is switched off
+     */
+    private int ceiling(VentOfferings offerings) {
+        double multiplier = addon.getSettings().getGeyserRewardCeiling();
+        if (multiplier <= 0) {
+            return GeyserOffer.NO_CEILING;
+        }
+        return Math.max(1, (int) Math.round(offerings.topValue * multiplier));
     }
 
     /**
@@ -342,8 +621,8 @@ public class GeyserOfferingsTask {
      * outward motion so the rewards scatter around the vent instead of falling
      * straight back into the pool.
      */
-    private Item launchReward(World world, Location spawn, GeyserLootEntry entry) {
-        Item item = world.dropItem(spawn, entry.toItemStack(RAND));
+    private Item launchReward(World world, Location spawn, ItemStack stack) {
+        Item item = world.dropItem(spawn, stack);
         item.getPersistentDataContainer().set(REWARD_KEY, PersistentDataType.BYTE, (byte) 1);
         double angle = RAND.nextDouble() * 2 * Math.PI;
         double horizontal = 0.1 + RAND.nextDouble() * 0.3;

--- a/src/main/java/world/bentobox/acidisland/geysers/GeyserValues.java
+++ b/src/main/java/world/bentobox/acidisland/geysers/GeyserValues.java
@@ -1,0 +1,199 @@
+package world.bentobox.acidisland.geysers;
+
+import java.io.File;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.inventory.ItemStack;
+import org.eclipse.jdt.annotation.Nullable;
+
+import world.bentobox.acidisland.AcidIsland;
+import world.bentobox.bentobox.api.addons.Addon;
+
+/**
+ * What a material is worth to a sulfur vent, so an offering can be answered
+ * with rewards of roughly equal worth rather than a random handful. A vent
+ * transmutes rather than destroys: feed it a diamond and it owes you a
+ * diamond's worth back.
+ * <p>
+ * Values are resolved in this order, first hit wins:
+ * <ol>
+ * <li>{@code values:} in {@code geyser-values.yml} - the admin's word is final</li>
+ * <li>the Level addon's block values for this world, if it is installed and
+ * {@code use-level-addon} is true, so a server that has already tuned what
+ * blocks are worth does not have to tune it twice</li>
+ * <li>{@code default:} in {@code geyser-values.yml}</li>
+ * </ol>
+ * The Level addon is optional and not a compile dependency, so it is reached
+ * reflectively and simply ignored if it is absent or its API has moved on.
+ *
+ * @author tastybento
+ * @since 2.1.1
+ */
+public class GeyserValues {
+
+    private final AcidIsland addon;
+    /** Values from geyser-values.yml, and the resolved value of every material asked for so far. */
+    private final Map<Material, Integer> values = new EnumMap<>(Material.class);
+    private int defaultValue = 1;
+    private boolean useLevelAddon = true;
+    /** Level's BlockConfig#getValue(World, Object), or null if Level is not usable. */
+    private @Nullable MethodHandle levelValue;
+    private @Nullable Object levelConfig;
+    private boolean levelChecked;
+
+    public GeyserValues(AcidIsland addon) {
+        this.addon = addon;
+        load();
+    }
+
+    private void load() {
+        File file = new File(addon.getDataFolder(), "geyser-values.yml");
+        if (!file.exists()) {
+            addon.saveResource("geyser-values.yml", false);
+        }
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
+        defaultValue = Math.max(0, config.getInt("default", 1));
+        useLevelAddon = config.getBoolean("use-level-addon", true);
+        ConfigurationSection section = config.getConfigurationSection("values");
+        if (section == null) {
+            return;
+        }
+        for (String key : section.getKeys(false)) {
+            Material material = Material.matchMaterial(key);
+            if (material == null) {
+                // Materials from newer Minecraft versions are listed on purpose - skip quietly
+                continue;
+            }
+            values.put(material, Math.max(0, section.getInt(key)));
+        }
+    }
+
+    /**
+     * @param material the material offered or rewarded
+     * @return what one of it is worth to a vent
+     */
+    public int getValue(Material material) {
+        Integer value = values.get(material);
+        if (value != null) {
+            return value;
+        }
+        int resolved = fromLevelAddon(material).orElse(defaultValue);
+        values.put(material, resolved);
+        return resolved;
+    }
+
+    /**
+     * @param stack the stack offered
+     * @return what the whole stack is worth to a vent
+     */
+    public int getValue(ItemStack stack) {
+        return getValue(stack.getType()) * stack.getAmount();
+    }
+
+    /**
+     * What one payout of a loot entry costs the vent. Item entries are worth
+     * their material unless the entry sets its own {@code value}; command
+     * entries are free unless they set one.
+     *
+     * @param entry the loot entry
+     * @return the cost of one of it
+     */
+    public int unitValue(GeyserLootEntry entry) {
+        if (entry.value() != null) {
+            return entry.value();
+        }
+        return entry.material() == null ? 0 : getValue(entry.material());
+    }
+
+    /**
+     * @return the fallback value for materials nothing else knows about
+     */
+    public int getDefaultValue() {
+        return defaultValue;
+    }
+
+    /**
+     * Ask the Level addon what a block is worth in this world. Looked up
+     * lazily and cached, so load order does not matter.
+     *
+     * @param material the material
+     * @return the Level addon's value, or empty if it has none or is not installed
+     */
+    // MethodHandle#invoke is declared to throw Throwable, and a broken hook
+    // into another addon must never take the vent down with it
+    @SuppressWarnings("java:S1181")
+    private Optional<Integer> fromLevelAddon(Material material) {
+        if (!useLevelAddon) {
+            return Optional.empty();
+        }
+        if (!levelChecked) {
+            hookLevelAddon();
+        }
+        if (levelValue == null) {
+            return Optional.empty();
+        }
+        World world = addon.getOverWorld();
+        try {
+            Object value = levelValue.invoke(levelConfig, world, material);
+            return value instanceof Integer i && i > 0 ? Optional.of(i) : Optional.empty();
+        } catch (Throwable e) {
+            // Level has changed under us - stop asking
+            levelValue = null;
+            addon.logWarning("Could not read block values from the Level addon: " + e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Look up {@code Level#getBlockConfig()} and {@code BlockConfig#getValue()}
+     * once, by method handle.
+     * <p>
+     * Deliberately not {@link Class#getMethod(String, Class...)}: that builds
+     * the whole declared-method list of Level's class first, which makes the
+     * JVM load every class named in every one of its signatures. Level has
+     * methods that mention its own soft dependencies, so on a server without
+     * Visit installed that throws {@code NoClassDefFoundError} before it ever
+     * reaches the method we want. A method handle resolves only the member
+     * asked for, so the missing optional classes are never touched.
+     */
+    // Throwable on purpose: the failure this guards against is a LinkageError,
+    // not an exception, and MethodHandle#invoke is declared to throw Throwable
+    @SuppressWarnings("java:S1181")
+    private void hookLevelAddon() {
+        levelChecked = true;
+        Optional<Addon> level = addon.getPlugin().getAddonsManager().getAddonByName("Level");
+        if (level.isEmpty()) {
+            return;
+        }
+        Addon levelAddon = level.get();
+        try {
+            Class<?> blockConfigClass = Class.forName("world.bentobox.level.config.BlockConfig", false,
+                    levelAddon.getClass().getClassLoader());
+            MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+            Object config = lookup
+                    .findVirtual(levelAddon.getClass(), "getBlockConfig", MethodType.methodType(blockConfigClass))
+                    .invoke(levelAddon);
+            if (config == null) {
+                return;
+            }
+            levelValue = lookup.findVirtual(blockConfigClass, "getValue",
+                    MethodType.methodType(Integer.class, World.class, Object.class));
+            levelConfig = config;
+            addon.log("Geyser offerings will use the Level addon's block values where geyser-values.yml is silent.");
+        } catch (Throwable e) {
+            // Level absent, shaded differently, or its API has moved on - the
+            // values file alone is a perfectly good source of worth
+            addon.logWarning("Could not hook into the Level addon for block values, using geyser-values.yml only: "
+                    + e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -167,8 +167,11 @@ world:
   # Requires Minecraft 26.2 or later - ignored on older servers.
   sulfur-vent-chance: 10
   # Geyser offerings
-  # Items thrown into the water around a sulfur vent are consumed as offerings and
-  # transmuted into rewards that are spewed out when the vent next erupts as a geyser.
+  # Items a player throws into the water around a sulfur vent are consumed as offerings
+  # and transmuted into rewards that are spewed out when the vent erupts as a geyser.
+  # Items floating near a vent are tugged into its pool, so a throw does not have to be
+  # accurate. Only items thrown by a player count - death drops, block drops and mob
+  # drops that wash into a pool are left alone.
   # Rewards are defined in geyser-loot.yml in the addon's data folder.
   # Works with acid item destruction: items the acid destroys within a vent's pool
   # count as offerings instead of being lost.
@@ -177,6 +180,27 @@ world:
     enabled: true
     # Maximum number of rewards a single eruption can spew, however many items were offered.
     max-rewards: 12
+    # Answer an offering with rewards of roughly the same worth, instead of one random
+    # reward per item. A vent transmutes rather than destroys: feed it a diamond and it
+    # owes a diamond's worth back, feed it cobble and it owes cobble. Worth comes from
+    # geyser-values.yml, which can defer to the Level addon's block values.
+    # Turn this off for the old one-roll-per-item payout.
+    match-value: true
+    # Fraction of the offered worth a vent pays back when matching worth.
+    # 1.0 is a fair trade, below 1.0 makes the vent take a cut, above 1.0 makes offering
+    # profitable in itself - which players will farm, so raise with care.
+    exchange-rate: 1.0
+    # The most a single reward may be worth, as a multiple of the worth of the richest
+    # item offered. A stack of cobble is worth an emerald and a cobble generator is
+    # infinite, so without this a vent becomes a gem printer. Rewards named in a from:
+    # list in geyser-loot.yml ignore this - a transmutation the admin has written down
+    # is always allowed. Set to 0 for no limit.
+    reward-ceiling: 8.0
+    # Provoke a fed vent into erupting a few seconds after it is fed, instead of waiting
+    # for the vanilla eruption cycle, so the reward follows the offering while the player
+    # is still there to see it. Turn this off to leave eruption timing entirely to vanilla
+    # - offerings are then held until the vent erupts.
+    erupt-on-offering: true
   # Structures
   # This creates an vanilla structures in the worlds.
   # Trial chambers and other underground structures generate buried

--- a/src/main/resources/geyser-loot.yml
+++ b/src/main/resources/geyser-loot.yml
@@ -1,23 +1,47 @@
 # Geyser offering rewards
 #
-# Items thrown into the water around a sulfur vent are consumed as offerings.
-# When the vent next erupts, one reward is rolled per item offered (capped by
-# world.geyser-offerings.max-rewards in config.yml) and spewed from the plume.
+# Items a player throws into the water around a sulfur vent are consumed as
+# offerings, and the vent erupts a few seconds later. What it spews back is
+# rolled from this table.
+#
+# With world.geyser-offerings.match-value on (the default) the vent owes back
+# what it was fed: it adds up the worth of the offerings from geyser-values.yml
+# and keeps rolling rewards it can still afford until that worth is spent,
+# capped by world.geyser-offerings.max-rewards. It cannot roll a reward it
+# cannot afford, and it leans away from entries worth a pittance next to what
+# it owes - so a diamond comes back in gems, and a stack of cobble comes back
+# in cobble-grade tat.
 #
 # Each entry is either an item or a console command:
 #   - {item: RAW_IRON, weight: 30, channel: mineral, amount: {min: 1, max: 3}}
-#   - {command: "give %player% cod 1", weight: 1}
+#   - {item: OBSIDIAN, weight: 10, from: [MAGMA_BLOCK, BASALT]}
+#   - {command: "give %player% cod 1", weight: 1, value: 4}
 # weight   - relative chance of the entry rolling (higher = more common)
-# channel  - optional. Offerings bias the table towards their own channel:
-#            every item sacrificed in a channel adds +50% to that channel's
-#            entry weights for the payout. Channels are assigned by material:
+# channel  - optional. Offerings pull the table towards their own channel by
+#            the share of the offering's worth that went into it: an offering
+#            that was nothing but gems makes gems entries four times as likely,
+#            an offering half gems by worth pulls half as hard. Worth pulls, not
+#            item count, so one diamond steers as firmly as the stack of cobble
+#            it is worth. Channels are assigned by material:
 #            gems      - diamonds, emeralds, amethyst, lapis, ender pearls
 #            nether    - netherrack, quartz, blaze, magma, soul, crimson/warped
 #            mineral   - ores, raw metals, ingots, nuggets, stone types
 #            forestry  - logs, planks, saplings, leaves, bamboo, kelp
 #            husbandry - wool, leather, string, feathers, eggs, any food
 #            Anything else burns with no bias but still counts as an offering.
+# from     - optional list of materials that transmute into this reward.
+#            Offer any of them and this entry becomes eight times as likely, so
+#            "magma blocks make obsidian" is something a player can learn and
+#            rely on. A from: entry also ignores world.geyser-offerings.
+#            reward-ceiling, so it is the only way for a vent to hand back
+#            something far richer than what went in - which makes it the place
+#            to move rewards that would otherwise need a mob farm or a
+#            challenge, like records from bones and gunpowder.
 # amount   - optional item count, fixed or a {min, max} range (default 1)
+# value    - optional worth of one of this reward, overriding the material's
+#            worth in geyser-values.yml. Command rewards are free unless they
+#            set this, so give paid commands a value or they will turn up in
+#            every payout.
 #
 # The geyser gives back what it is fed, changed: sacrifice ores to be paid in
 # gems, sacrifice wood to be paid in living things. Materials from Minecraft
@@ -31,31 +55,46 @@ loot:
   - {item: PRISMARINE_SHARD, weight: 15, amount: {min: 1, max: 2}}
   - {item: PRISMARINE_CRYSTALS, weight: 8}
   - {item: SEA_PICKLE, weight: 6}
-  - {item: NAUTILUS_SHELL, weight: 3}
-  - {item: HEART_OF_THE_SEA, weight: 1}
+  - {item: NAUTILUS_SHELL, weight: 3, from: [PRISMARINE_SHARD, PRISMARINE_CRYSTALS]}
+  - {item: HEART_OF_THE_SEA, weight: 1, from: [NAUTILUS_SHELL]}
   # Mineral channel - fed by stone, ores and metals
   - {item: IRON_NUGGET, weight: 20, channel: mineral, amount: {min: 2, max: 5}}
   - {item: RAW_COPPER, weight: 15, channel: mineral, amount: {min: 1, max: 3}}
   - {item: RAW_IRON, weight: 12, channel: mineral, amount: {min: 1, max: 2}}
   - {item: RAW_GOLD, weight: 6, channel: mineral}
   - {item: REDSTONE, weight: 8, channel: mineral, amount: {min: 1, max: 4}}
+  # Iron into gold: the vent's oldest trick
+  - {item: GOLD_INGOT, weight: 5, channel: mineral, from: [IRON_INGOT, RAW_IRON, IRON_BLOCK]}
   # Gems channel - the vent's rarest vein
   - {item: AMETHYST_SHARD, weight: 8, channel: gems, amount: {min: 1, max: 2}}
   - {item: LAPIS_LAZULI, weight: 8, channel: gems, amount: {min: 2, max: 4}}
-  - {item: EMERALD, weight: 3, channel: gems}
-  - {item: DIAMOND, weight: 2, channel: gems}
+  - {item: EMERALD, weight: 3, channel: gems, from: [DIAMOND, DIAMOND_BLOCK]}
+  - {item: DIAMOND, weight: 2, channel: gems, from: [EMERALD, EMERALD_BLOCK, AMETHYST_SHARD]}
   # Nether channel - heat calls to heat
   - {item: QUARTZ, weight: 10, channel: nether, amount: {min: 1, max: 3}}
   - {item: GLOWSTONE_DUST, weight: 8, channel: nether, amount: {min: 1, max: 2}}
   - {item: BLAZE_POWDER, weight: 4, channel: nether}
-  - {item: ANCIENT_DEBRIS, weight: 1, channel: nether}
+  - {item: ANCIENT_DEBRIS, weight: 1, channel: nether, from: [CRYING_OBSIDIAN, NETHERITE_SCRAP]}
+  # Water meeting fire, the way the ocean floor makes it
+  - {item: OBSIDIAN, weight: 10, channel: nether, from: [MAGMA_BLOCK, BASALT, LAVA_BUCKET]}
+  - {item: CRYING_OBSIDIAN, weight: 3, channel: nether, from: [OBSIDIAN, GHAST_TEAR]}
+  - {item: BLAZE_ROD, weight: 2, channel: nether, from: [MAGMA_CREAM, BLAZE_POWDER]}
   # Forestry channel - green things from a dead sea
   - {item: KELP, weight: 12, channel: forestry, amount: {min: 1, max: 3}}
   - {item: BAMBOO, weight: 8, channel: forestry, amount: {min: 1, max: 4}}
   - {item: MANGROVE_PROPAGULE, weight: 5, channel: forestry}
   - {item: OAK_SAPLING, weight: 5, channel: forestry}
+  - {item: SPONGE, weight: 3, channel: forestry, from: [KELP, SEAGRASS, DRIED_KELP_BLOCK]}
   # Husbandry channel - the boiled bounty of the deep
   - {item: COOKED_COD, weight: 12, channel: husbandry, amount: {min: 1, max: 2}}
   - {item: COOKED_SALMON, weight: 8, channel: husbandry}
   - {item: LEATHER, weight: 6, channel: husbandry, amount: {min: 1, max: 2}}
   - {item: TURTLE_EGG, weight: 2, channel: husbandry}
+  # A skeleton shooting a creeper is the vanilla way to get a record. Bones and
+  # gunpowder thrown into a vent are the AcidIsland way.
+  - {item: MUSIC_DISC_13, weight: 1, from: [BONE, GUNPOWDER]}
+  - {item: MUSIC_DISC_CAT, weight: 1, from: [BONE, GUNPOWDER]}
+  - {item: MUSIC_DISC_BLOCKS, weight: 1, from: [BONE, GUNPOWDER]}
+  - {item: MUSIC_DISC_CHIRP, weight: 1, from: [BONE, GUNPOWDER]}
+  - {item: MUSIC_DISC_MALL, weight: 1, from: [BONE, GUNPOWDER]}
+  - {item: MUSIC_DISC_STAL, weight: 1, from: [BONE, GUNPOWDER]}

--- a/src/main/resources/geyser-values.yml
+++ b/src/main/resources/geyser-values.yml
@@ -1,0 +1,250 @@
+# Sulfur vent offering worth
+#
+# What a material is worth to a sulfur vent. A vent transmutes rather than
+# destroys: offer it a diamond and it owes you a diamond's worth of rewards
+# back (times world.geyser-offerings.exchange-rate in config.yml). Offer it a
+# stack of cobble and it owes you cobble-grade tat.
+#
+# The scale is arbitrary - only the ratios matter. It is anchored on
+# iron ingot = 6, gold ingot = 12, emerald = 15, diamond = 45, so a diamond
+# comes back as three emeralds, or an emerald and two gold ingots, and so on.
+#
+# Worth is resolved in this order, first hit wins:
+#   1. the values below
+#   2. the Level addon's block values for this world, if Level is installed and
+#      use-level-addon is true. Delete an entry below to defer to Level for it.
+#   3. default, for anything nothing else knows about
+#
+# Worth is by material only: enchantments, custom names and the contents of
+# shulker boxes are not counted, so gear is worth its base material.
+#
+# Materials from Minecraft 26.2 (SULFUR, CINNABAR, POTENT_SULFUR) are safe to
+# list - any name this server does not know is skipped silently.
+
+# Worth of a material nothing else has a value for
+default: 1
+# Fall back to the Level addon's block values where this file is silent
+use-level-addon: true
+
+values:
+  # Stone, dirt and other bulk
+  COBBLESTONE: 1
+  STONE: 1
+  DEEPSLATE: 1
+  COBBLED_DEEPSLATE: 1
+  ANDESITE: 1
+  DIORITE: 1
+  GRANITE: 1
+  TUFF: 1
+  CALCITE: 2
+  DRIPSTONE_BLOCK: 2
+  DIRT: 1
+  GRAVEL: 1
+  SAND: 1
+  RED_SAND: 1
+  SANDSTONE: 2
+  CLAY_BALL: 2
+  FLINT: 2
+  SNOWBALL: 1
+  ICE: 2
+  GLASS: 2
+  NETHERRACK: 1
+  BASALT: 1
+  BLACKSTONE: 2
+  SOUL_SAND: 3
+  SOUL_SOIL: 3
+  OBSIDIAN: 8
+  CRYING_OBSIDIAN: 20
+  MAGMA_BLOCK: 4
+  GLOWSTONE: 12
+  SHROOMLIGHT: 8
+  SCULK: 4
+  # Sulfur vents (Minecraft 26.2+)
+  SULFUR: 3
+  SULFUR_SPIKE: 3
+  CINNABAR: 8
+  POTENT_SULFUR: 20
+  # Wood and green things
+  OAK_LOG: 3
+  SPRUCE_LOG: 3
+  BIRCH_LOG: 3
+  JUNGLE_LOG: 3
+  ACACIA_LOG: 3
+  DARK_OAK_LOG: 3
+  MANGROVE_LOG: 3
+  CHERRY_LOG: 3
+  PALE_OAK_LOG: 3
+  CRIMSON_STEM: 3
+  WARPED_STEM: 3
+  OAK_PLANKS: 1
+  OAK_SAPLING: 4
+  MANGROVE_PROPAGULE: 4
+  KELP: 1
+  SEAGRASS: 1
+  BAMBOO: 1
+  SUGAR_CANE: 2
+  CACTUS: 2
+  VINE: 2
+  BROWN_MUSHROOM: 2
+  RED_MUSHROOM: 2
+  NETHER_WART: 4
+  CHORUS_FRUIT: 5
+  # Food and farming
+  WHEAT: 3
+  WHEAT_SEEDS: 1
+  POTATO: 2
+  CARROT: 2
+  BEETROOT: 2
+  PUMPKIN: 3
+  MELON_SLICE: 1
+  APPLE: 3
+  BREAD: 3
+  COD: 2
+  SALMON: 2
+  COOKED_COD: 3
+  COOKED_SALMON: 3
+  TROPICAL_FISH: 4
+  PUFFERFISH: 6
+  SWEET_BERRIES: 2
+  GLOW_BERRIES: 4
+  COCOA_BEANS: 2
+  HONEYCOMB: 4
+  GOLDEN_APPLE: 40
+  ENCHANTED_GOLDEN_APPLE: 300
+  GOLDEN_CARROT: 12
+  # Ores and metals
+  COAL: 3
+  CHARCOAL: 2
+  RAW_COPPER: 2
+  COPPER_INGOT: 3
+  RAW_IRON: 5
+  IRON_INGOT: 6
+  IRON_NUGGET: 1
+  RAW_GOLD: 10
+  GOLD_INGOT: 12
+  GOLD_NUGGET: 1
+  REDSTONE: 4
+  LAPIS_LAZULI: 5
+  QUARTZ: 5
+  AMETHYST_SHARD: 6
+  EMERALD: 15
+  DIAMOND: 45
+  NETHERITE_SCRAP: 120
+  NETHERITE_INGOT: 500
+  ANCIENT_DEBRIS: 120
+  COAL_ORE: 3
+  COPPER_ORE: 8
+  IRON_ORE: 5
+  GOLD_ORE: 10
+  REDSTONE_ORE: 20
+  LAPIS_ORE: 20
+  DIAMOND_ORE: 45
+  EMERALD_ORE: 15
+  NETHER_QUARTZ_ORE: 5
+  NETHER_GOLD_ORE: 4
+  # Storage blocks - nine of the thing, worth nine of the thing
+  COAL_BLOCK: 27
+  COPPER_BLOCK: 27
+  IRON_BLOCK: 54
+  GOLD_BLOCK: 108
+  REDSTONE_BLOCK: 36
+  LAPIS_BLOCK: 45
+  AMETHYST_BLOCK: 24
+  EMERALD_BLOCK: 135
+  DIAMOND_BLOCK: 405
+  NETHERITE_BLOCK: 4500
+  # Mob drops
+  STRING: 2
+  FEATHER: 2
+  BONE: 2
+  BONE_MEAL: 1
+  ROTTEN_FLESH: 1
+  SPIDER_EYE: 3
+  GUNPOWDER: 4
+  SLIME_BALL: 4
+  MAGMA_CREAM: 8
+  INK_SAC: 2
+  GLOW_INK_SAC: 6
+  LEATHER: 3
+  RABBIT_HIDE: 2
+  RABBIT_FOOT: 12
+  PHANTOM_MEMBRANE: 10
+  ENDER_PEARL: 12
+  BLAZE_ROD: 24
+  BLAZE_POWDER: 12
+  GHAST_TEAR: 30
+  DRAGON_BREATH: 20
+  SHULKER_SHELL: 60
+  TOTEM_OF_UNDYING: 150
+  NETHER_STAR: 400
+  ELYTRA: 400
+  TRIDENT: 120
+  ECHO_SHARD: 30
+  WHITE_WOOL: 2
+  EGG: 2
+  TURTLE_EGG: 15
+  TURTLE_SCUTE: 15
+  # The sea
+  PRISMARINE_SHARD: 3
+  PRISMARINE_CRYSTALS: 5
+  SEA_PICKLE: 3
+  SPONGE: 20
+  NAUTILUS_SHELL: 20
+  HEART_OF_THE_SEA: 90
+  # Records - the usual reason to build a mob farm
+  MUSIC_DISC_13: 40
+  MUSIC_DISC_CAT: 40
+  MUSIC_DISC_BLOCKS: 40
+  MUSIC_DISC_CHIRP: 40
+  MUSIC_DISC_FAR: 40
+  MUSIC_DISC_MALL: 40
+  MUSIC_DISC_MELLOHI: 40
+  MUSIC_DISC_STAL: 40
+  MUSIC_DISC_STRAD: 40
+  MUSIC_DISC_WARD: 40
+  MUSIC_DISC_11: 40
+  MUSIC_DISC_WAIT: 40
+  MUSIC_DISC_PIGSTEP: 90
+  MUSIC_DISC_OTHERSIDE: 90
+  MUSIC_DISC_5: 90
+  MUSIC_DISC_RELIC: 90
+  DISC_FRAGMENT_5: 10
+  # Gear, at the worth of the material it is made from
+  IRON_SWORD: 12
+  IRON_PICKAXE: 18
+  IRON_AXE: 18
+  IRON_SHOVEL: 6
+  IRON_HELMET: 30
+  IRON_CHESTPLATE: 48
+  IRON_LEGGINGS: 42
+  IRON_BOOTS: 24
+  GOLDEN_SWORD: 24
+  GOLDEN_PICKAXE: 36
+  GOLDEN_HELMET: 60
+  GOLDEN_CHESTPLATE: 96
+  DIAMOND_SWORD: 90
+  DIAMOND_PICKAXE: 135
+  DIAMOND_AXE: 135
+  DIAMOND_SHOVEL: 45
+  DIAMOND_HELMET: 225
+  DIAMOND_CHESTPLATE: 360
+  DIAMOND_LEGGINGS: 315
+  DIAMOND_BOOTS: 180
+  NETHERITE_SWORD: 590
+  NETHERITE_PICKAXE: 635
+  NETHERITE_HELMET: 725
+  NETHERITE_CHESTPLATE: 860
+  NETHERITE_LEGGINGS: 815
+  NETHERITE_BOOTS: 680
+  # Odds and ends worth more than they look
+  ENCHANTED_BOOK: 30
+  EXPERIENCE_BOTTLE: 8
+  NAME_TAG: 20
+  SADDLE: 20
+  LAVA_BUCKET: 20
+  WATER_BUCKET: 12
+  BUCKET: 18
+  ENDER_EYE: 20
+  END_CRYSTAL: 60
+  BEACON: 400
+  CONDUIT: 200

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -15,3 +15,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>Kyselá voda"
     lore-purified: "<green>Čistá voda"
+  geyser:
+    offering: "[actionbar]<dark_aqua>Průduch syčí a pohlcuje <yellow>[item]</yellow>."
+    offering-channel: "[actionbar]<dark_aqua>Průduch syčí a pohlcuje <yellow>[item]</yellow> <gray>([channel])"
+    churning: "[actionbar]<dark_aqua>Průduch vře a začíná bobtnat..."
+    payout: "[actionbar]<gold>Gejzír vybuchuje a odpovídá na vaše oběti."
+    payout-channel: "[actionbar]<gold>Gejzír vybuchuje a odpovídá <yellow>[channel]</yellow> stejným způsobem."
+    channels:
+      gems: "drahokamy"
+      nether: "oheň"
+      mineral: "kámen a kov"
+      forestry: "zeleň"
+      husbandry: "živé tvory"

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -8,3 +8,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>Säurewasser"
     lore-purified: "<green>Gereinigtes Wasser"
+  geyser:
+    offering: "[actionbar]<dark_aqua>Der Schlund zischt und verschlingt <yellow>[item]</yellow>."
+    offering-channel: "[actionbar]<dark_aqua>Der Schlund zischt und verschlingt <yellow>[item]</yellow> <gray>([channel])"
+    churning: "[actionbar]<dark_aqua>Der Schlund brodelt und beginnt zu schwellen..."
+    payout: "[actionbar]<gold>Der Geysir bricht aus und beantwortet deine Opfergaben."
+    payout-channel: "[actionbar]<gold>Der Geysir bricht aus und beantwortet <yellow>[channel]</yellow> gebührend."
+    channels:
+      gems: "Edelsteine"
+      nether: "Feuer"
+      mineral: "Stein und Metall"
+      forestry: "Pflanzen"
+      husbandry: "Kreaturen"

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -12,3 +12,19 @@ acidisland:
   purified-water:
     lore-acid: "<red>Acid Water"
     lore-purified: "<green>Purified Water"
+  geyser:
+    # Sent to the player who threw an item into a sulfur vent's pool.
+    # Remove the [actionbar] tag to send these in chat instead.
+    offering: "[actionbar]<dark_aqua>The vent hisses and swallows <yellow>[item]</yellow>."
+    offering-channel: "[actionbar]<dark_aqua>The vent hisses and swallows <yellow>[item]</yellow> <gray>([channel])"
+    churning: "[actionbar]<dark_aqua>The vent churns and begins to swell..."
+    payout: "[actionbar]<gold>The geyser erupts and answers your offerings."
+    payout-channel: "[actionbar]<gold>The geyser erupts, answering <yellow>[channel]</yellow> in kind."
+    # Names of the reward channels in geyser-loot.yml. A channel with no entry
+    # here is named by its raw key.
+    channels:
+      gems: "gems"
+      nether: "fire"
+      mineral: "stone and metal"
+      forestry: "green things"
+      husbandry: "living things"

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -12,3 +12,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>Agua ácida"
     lore-purified: "<green>Agua purificada"
+  geyser:
+    offering: "[actionbar]<dark_aqua>La fumarola silba y traga <yellow>[item]</yellow>."
+    offering-channel: "[actionbar]<dark_aqua>La fumarola silba y traga <yellow>[item]</yellow> <gray>([channel])"
+    churning: "[actionbar]<dark_aqua>La fumarola hierve y comienza a hincharse..."
+    payout: "[actionbar]<gold>El géyser erupciona y responde a tus ofrendas."
+    payout-channel: "[actionbar]<gold>El géyser erupciona, respondiendo a <yellow>[channel]</yellow> de manera similar."
+    channels:
+      gems: "gemas"
+      nether: "fuego"
+      mineral: "piedra y metal"
+      forestry: "verdor"
+      husbandry: "criaturas"

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -8,3 +8,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>Eau acide"
     lore-purified: "<green>Eau purifiée"
+  geyser:
+    offering: "[actionbar]<dark_aqua>La cheminée siffle et engloutit <yellow>[item]</yellow>."
+    offering-channel: "[actionbar]<dark_aqua>La cheminée siffle et engloutit <yellow>[item]</yellow> <gray>([channel])"
+    churning: "[actionbar]<dark_aqua>La cheminée bouillonne et commence à enfler..."
+    payout: "[actionbar]<gold>Le géyser érupte et répond à vos offrandes."
+    payout-channel: "[actionbar]<gold>Le géyser érupte, répondant au <yellow>[channel]</yellow> en retour."
+    channels:
+      gems: "gemmes"
+      nether: "feu"
+      mineral: "pierre et métal"
+      forestry: "verdure"
+      husbandry: "créatures"

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -8,3 +8,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>Kisela voda"
     lore-purified: "<green>Pročišćena voda"
+  geyser:
+    offering: "[actionbar]<dark_aqua>Otvor šišti i proguta <yellow>[item]</yellow>."
+    offering-channel: "[actionbar]<dark_aqua>Otvor šišti i proguta <yellow>[item]</yellow> <gray>([channel])"
+    churning: "[actionbar]<dark_aqua>Otvor se vrti i počinje bubriti..."
+    payout: "[actionbar]<gold>Gejzir se aktivira i odgovara vašim darivanjima."
+    payout-channel: "[actionbar]<gold>Gejzir se aktivira, odgovarajući <yellow>[channel]</yellow> na isti način."
+    channels:
+      gems: "drago kamenje"
+      nether: "vatra"
+      mineral: "kamen i metal"
+      forestry: "zelene stvari"
+      husbandry: "živa bića"

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -13,3 +13,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>Savas víz"
     lore-purified: "<green>Tisztított víz"
+  geyser:
+    offering: "[actionbar]<dark_aqua>A kürtő sziszegve elnyeli: <yellow>[item]</yellow>."
+    offering-channel: "[actionbar]<dark_aqua>A kürtő sziszegve elnyeli: <yellow>[item]</yellow> <gray>([channel])"
+    churning: "[actionbar]<dark_aqua>A kürtő forr és duzzadni kezd..."
+    payout: "[actionbar]<gold>A gejzír kitör és válaszol az áldozataidra."
+    payout-channel: "[actionbar]<gold>A gejzír kitör, és <yellow>[channel]</yellow> formájában válaszol."
+    channels:
+      gems: "drágakövek"
+      nether: "tűz"
+      mineral: "kő és fém"
+      forestry: "növények"
+      husbandry: "élőlények"

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -9,3 +9,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>Air asam"
     lore-purified: "<green>Air murni"
+  geyser:
+    offering: "[actionbar]<dark_aqua>Lubang belerang mendesis dan menelan <yellow>[item]</yellow>."
+    offering-channel: "[actionbar]<dark_aqua>Lubang belerang mendesis dan menelan <yellow>[item]</yellow> <gray>([channel])"
+    churning: "[actionbar]<dark_aqua>Lubang belerang bergolak dan mulai membengkak..."
+    payout: "[actionbar]<gold>Geiser meletus dan menjawab persembahanmu."
+    payout-channel: "[actionbar]<gold>Geiser meletus, membalas dengan <yellow>[channel]</yellow>."
+    channels:
+      gems: "permata"
+      nether: "api"
+      mineral: "batu dan logam"
+      forestry: "tumbuhan"
+      husbandry: "makhluk hidup"

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -12,3 +12,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>Acqua acida"
     lore-purified: "<green>Acqua purificata"
+  geyser:
+    offering: "[actionbar]<dark_aqua>Il camino sibila e inghiotte <yellow>[item]</yellow>."
+    offering-channel: "[actionbar]<dark_aqua>Il camino sibila e inghiotte <yellow>[item]</yellow> <gray>([channel])"
+    churning: "[actionbar]<dark_aqua>Il camino bolle e inizia a gonfiarsi..."
+    payout: "[actionbar]<gold>Il geyser erutta e risponde alle tue offerte."
+    payout-channel: "[actionbar]<gold>Il geyser erutta, rispondendo al <yellow>[channel]</yellow> allo stesso modo."
+    channels:
+      gems: "gemme"
+      nether: "fuoco"
+      mineral: "pietra e metallo"
+      forestry: "verdura"
+      husbandry: "creature"

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -8,3 +8,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>酸性の水"
     lore-purified: "<green>浄化された水"
+  geyser:
+    offering: "[actionbar]<dark_aqua>噴出孔がシューッと音を立てて<yellow>[item]</yellow>を吞み込む。"
+    offering-channel: "[actionbar]<dark_aqua>噴出孔がシューッと音を立てて<yellow>[item]</yellow>を吞み込む。<gray>([channel])"
+    churning: "[actionbar]<dark_aqua>噴出孔が渦を巻き、膨れ始める..."
+    payout: "[actionbar]<gold>間欠泉が噴出し、あなたの供え物に応える。"
+    payout-channel: "[actionbar]<gold>間欠泉が噴出し、<yellow>[channel]</yellow>に応じ返す。"
+    channels:
+      gems: "宝石"
+      nether: "火"
+      mineral: "石と金属"
+      forestry: "緑のもの"
+      husbandry: "生き物"

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -8,3 +8,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>산성 물"
     lore-purified: "<green>정화된 물"
+  geyser:
+    offering: "[actionbar]<dark_aqua>분출공이 쉿하는 소리를 내며 <yellow>[item]</yellow>을 집어삼킨다."
+    offering-channel: "[actionbar]<dark_aqua>분출공이 쉿하는 소리를 내며 <yellow>[item]</yellow>을 집어삼킨다. <gray>([channel])"
+    churning: "[actionbar]<dark_aqua>분출공이 소용돌이 치며 부풀어 오르기 시작한다..."
+    payout: "[actionbar]<gold>간헐천이 분출하며 당신의 제물에 응한다."
+    payout-channel: "[actionbar]<gold>간헐천이 분출하며 <yellow>[channel]</yellow>에 동등하게 응한다."
+    channels:
+      gems: "보석"
+      nether: "불"
+      mineral: "돌과 금속"
+      forestry: "초목"
+      husbandry: "생명"

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -8,3 +8,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>Skābes ūdens"
     lore-purified: "<green>Attīrīts ūdens"
+  geyser:
+    offering: "[actionbar]<dark_aqua>Atvere šņāc un norij <yellow>[item]</yellow>."
+    offering-channel: "[actionbar]<dark_aqua>Atvere šņāc un norij <yellow>[item]</yellow> <gray>([channel])"
+    churning: "[actionbar]<dark_aqua>Atvere mutuļo un sāk uzbriest..."
+    payout: "[actionbar]<gold>Geizers izverd un atbild uz jūsu upuriem."
+    payout-channel: "[actionbar]<gold>Geizers izverd un atbild ar to pašu: <yellow>[channel]</yellow>."
+    channels:
+      gems: "dārgakmeņi"
+      nether: "uguns"
+      mineral: "akmens un metāls"
+      forestry: "zaļie augi"
+      husbandry: "dzīvās būtnes"

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -8,3 +8,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>Kwaśna woda"
     lore-purified: "<green>Oczyszczona woda"
+  geyser:
+    offering: "[actionbar]<dark_aqua>Komin syczy i pochłania <yellow>[item]</yellow>."
+    offering-channel: "[actionbar]<dark_aqua>Komin syczy i pochłania <yellow>[item]</yellow> <gray>([channel])"
+    churning: "[actionbar]<dark_aqua>Komin wrze i zaczyna puchnąć..."
+    payout: "[actionbar]<gold>Gejzer wybucha i odpowiada na twoje ofiary."
+    payout-channel: "[actionbar]<gold>Gejzer wybucha, odpowiadając <yellow>[channel]</yellow> w ten sam sposób."
+    channels:
+      gems: "klejnoty"
+      nether: "ogień"
+      mineral: "kamień i metal"
+      forestry: "zielone rzeczy"
+      husbandry: "żywe istoty"

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -9,3 +9,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>Apă acidă"
     lore-purified: "<green>Apă purificată"
+  geyser:
+    offering: "[actionbar]<dark_aqua>Gura vulcanului șuieră și înghite <yellow>[item]</yellow>."
+    offering-channel: "[actionbar]<dark_aqua>Gura vulcanului șuieră și înghite <yellow>[item]</yellow> <gray>([channel])"
+    churning: "[actionbar]<dark_aqua>Gura vulcanului clocotește și începe să se umfle..."
+    payout: "[actionbar]<gold>Geizerul eruptează și răspunde ofertelor tale."
+    payout-channel: "[actionbar]<gold>Geizerul eruptează, răspunzând <yellow>[channel]</yellow> în felul cuvenit."
+    channels:
+      gems: "pietre prețioase"
+      nether: "foc"
+      mineral: "piatră și metal"
+      forestry: "lucruri verzi"
+      husbandry: "lucruri vii"

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -8,3 +8,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>Кислотная вода"
     lore-purified: "<green>Очищенная вода"
+  geyser:
+    offering: "[actionbar]<dark_aqua>Жерло шипит и поглощает <yellow>[item]</yellow>."
+    offering-channel: "[actionbar]<dark_aqua>Жерло шипит и поглощает <yellow>[item]</yellow> <gray>([channel])"
+    churning: "[actionbar]<dark_aqua>Жерло кипит и начинает расширяться..."
+    payout: "[actionbar]<gold>Гейзер извергается и отвечает на ваши дары."
+    payout-channel: "[actionbar]<gold>Гейзер извергается, отвечая <yellow>[channel]</yellow> в равной мере."
+    channels:
+      gems: "драгоценности"
+      nether: "огонь"
+      mineral: "камень и металл"
+      forestry: "зелень"
+      husbandry: "живые существа"

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -8,3 +8,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>Asitli Su"
     lore-purified: "<green>Arıtılmış Su"
+  geyser:
+    offering: "[actionbar]<dark_aqua>Baca tıslayarak <yellow>[item]</yellow> yutuyor."
+    offering-channel: "[actionbar]<dark_aqua>Baca tıslayarak <yellow>[item]</yellow> yutuyor <gray>([channel])"
+    churning: "[actionbar]<dark_aqua>Baca kaynıyor ve şişmeye başlıyor..."
+    payout: "[actionbar]<gold>Gayzer püskürüyor ve adaklarına karşılık veriyor."
+    payout-channel: "[actionbar]<gold>Gayzer püskürüyor, <yellow>[channel]</yellow> ile karşılık veriyor."
+    channels:
+      gems: "mücevherler"
+      nether: "ateş"
+      mineral: "taş ve metal"
+      forestry: "bitkiler"
+      husbandry: "canlılar"

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -8,3 +8,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>Кислотна вода"
     lore-purified: "<green>Очищена вода"
+  geyser:
+    offering: "[actionbar]<dark_aqua>Жерло шипить і поглинає <yellow>[item]</yellow>."
+    offering-channel: "[actionbar]<dark_aqua>Жерло шипить і поглинає <yellow>[item]</yellow> <gray>([channel])"
+    churning: "[actionbar]<dark_aqua>Жерло кипить і починає розширюватися..."
+    payout: "[actionbar]<gold>Гейзер вибухає та відповідає на ваші дари."
+    payout-channel: "[actionbar]<gold>Гейзер вибухає, відповідаючи <yellow>[channel]</yellow> в рівній мірі."
+    channels:
+      gems: "дорогоцінності"
+      nether: "вогонь"
+      mineral: "камінь і метал"
+      forestry: "зелень"
+      husbandry: "живі істоти"

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -8,3 +8,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>Nước axit"
     lore-purified: "<green>Nước tinh khiết"
+  geyser:
+    offering: "[actionbar]<dark_aqua>Miệng phun rít lên và nuốt chửng <yellow>[item]</yellow>."
+    offering-channel: "[actionbar]<dark_aqua>Miệng phun rít lên và nuốt chửng <yellow>[item]</yellow> <gray>([channel])"
+    churning: "[actionbar]<dark_aqua>Miệng phun đang sục sôi và bắt đầu phồng lên..."
+    payout: "[actionbar]<gold>Mạch nước phun trào lên, đáp lại lễ vật của bạn."
+    payout-channel: "[actionbar]<gold>Mạch nước phun trào lên, đáp lại bằng <yellow>[channel]</yellow>."
+    channels:
+      gems: "đá quý"
+      nether: "lửa"
+      mineral: "đá và kim loại"
+      forestry: "cây cỏ"
+      husbandry: "sinh vật"

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -13,3 +13,15 @@ acidisland:
   purified-water:
     lore-acid: "<red>酸水"
     lore-purified: "<green>纯净水"
+  geyser:
+    offering: "[actionbar]<dark_aqua>喷口嘶声并吞下<yellow>[item]</yellow>。"
+    offering-channel: "[actionbar]<dark_aqua>喷口嘶声并吞下<yellow>[item]</yellow>。<gray>([channel])"
+    churning: "[actionbar]<dark_aqua>喷口翻滚，开始膨胀..."
+    payout: "[actionbar]<gold>间歇泉爆发，回应你的祭品。"
+    payout-channel: "[actionbar]<gold>间歇泉爆发，以同样方式回应<yellow>[channel]</yellow>。"
+    channels:
+      gems: "宝石"
+      nether: "火焰"
+      mineral: "石头与金属"
+      forestry: "植物"
+      husbandry: "生命"

--- a/src/test/java/world/bentobox/acidisland/AISettingsTest.java
+++ b/src/test/java/world/bentobox/acidisland/AISettingsTest.java
@@ -124,6 +124,34 @@ public class AISettingsTest {
     }
 
     @Test
+    void testIsGeyserMatchValue() {
+        assertTrue(s.isGeyserMatchValue());
+        s.setGeyserMatchValue(false);
+        assertFalse(s.isGeyserMatchValue());
+    }
+
+    @Test
+    void testGetGeyserExchangeRate() {
+        assertEquals(1.0, s.getGeyserExchangeRate());
+        s.setGeyserExchangeRate(0.75);
+        assertEquals(0.75, s.getGeyserExchangeRate());
+    }
+
+    @Test
+    void testGetGeyserRewardCeiling() {
+        assertEquals(8.0, s.getGeyserRewardCeiling());
+        s.setGeyserRewardCeiling(0);
+        assertEquals(0.0, s.getGeyserRewardCeiling());
+    }
+
+    @Test
+    void testIsGeyserEruptOnOffering() {
+        assertTrue(s.isGeyserEruptOnOffering());
+        s.setGeyserEruptOnOffering(false);
+        assertFalse(s.isGeyserEruptOnOffering());
+    }
+
+    @Test
     void testGetDifficulty() {
         assertEquals(Difficulty.NORMAL, s.getDifficulty());
     }

--- a/src/test/java/world/bentobox/acidisland/geysers/GeyserLootEntryTest.java
+++ b/src/test/java/world/bentobox/acidisland/geysers/GeyserLootEntryTest.java
@@ -2,11 +2,14 @@ package world.bentobox.acidisland.geysers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -109,5 +112,38 @@ class GeyserLootEntryTest {
     void testToItemStackFixedAmount() {
         GeyserLootEntry entry = new GeyserLootEntry(Material.DIAMOND, null, 1, "gems", 1, 1);
         assertEquals(1, entry.toItemStack(new Random(42)).getAmount());
+    }
+
+    @Test
+    void testParseValueAndFrom() {
+        GeyserLootEntry entry = GeyserLootEntry.parse(Map.of("item", "OBSIDIAN", "weight", 10, "value", 8, "from",
+                List.of("MAGMA_BLOCK", "BASALT", "NOT_A_MATERIAL")));
+        assertNotNull(entry);
+        assertEquals(8, entry.value());
+        // Unknown materials in a from: list are skipped, not fatal
+        assertEquals(Set.of(Material.MAGMA_BLOCK, Material.BASALT), entry.from());
+    }
+
+    @Test
+    void testParseWithoutValueOrFrom() {
+        GeyserLootEntry entry = GeyserLootEntry.parse(Map.of("item", "DIAMOND", "weight", 2));
+        assertNotNull(entry);
+        assertNull(entry.value());
+        assertTrue(entry.from().isEmpty());
+    }
+
+    @Test
+    void testParseFromIgnoresNonList() {
+        GeyserLootEntry entry = GeyserLootEntry.parse(Map.of("item", "DIAMOND", "from", "MAGMA_BLOCK"));
+        assertNotNull(entry);
+        assertTrue(entry.from().isEmpty());
+    }
+
+    @Test
+    void testToItemStackWithAmount() {
+        GeyserLootEntry entry = new GeyserLootEntry(Material.EMERALD, null, 1, "gems", 1, 1);
+        assertEquals(3, entry.toItemStack(3).getAmount());
+        // An amount of zero would spawn an empty stack
+        assertEquals(1, entry.toItemStack(0).getAmount());
     }
 }

--- a/src/test/java/world/bentobox/acidisland/geysers/GeyserLootTableTest.java
+++ b/src/test/java/world/bentobox/acidisland/geysers/GeyserLootTableTest.java
@@ -4,9 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -16,13 +22,19 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+
+import world.bentobox.acidisland.AcidIsland;
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.managers.AddonsManager;
 
 /**
  * @author tastybento
@@ -30,6 +42,16 @@ import org.mockito.quality.Strictness;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class GeyserLootTableTest {
+
+    @Mock
+    private AcidIsland addon;
+    @Mock
+    private BentoBox plugin;
+    @Mock
+    private AddonsManager addonsManager;
+
+    @TempDir
+    File dataFolder;
 
     private ServerMock server;
     private MockedStatic<Bukkit> mockedBukkit;
@@ -40,6 +62,10 @@ class GeyserLootTableTest {
         mockedBukkit = Mockito.mockStatic(Bukkit.class, Mockito.RETURNS_DEEP_STUBS);
         mockedBukkit.when(Bukkit::getMinecraftVersion).thenReturn("1.21.11");
         mockedBukkit.when(Bukkit::getServer).thenReturn(server);
+        when(addon.getDataFolder()).thenReturn(dataFolder);
+        when(addon.getPlugin()).thenReturn(plugin);
+        when(plugin.getAddonsManager()).thenReturn(addonsManager);
+        when(addonsManager.getAddonByName("Level")).thenReturn(Optional.empty());
     }
 
     @AfterEach
@@ -55,6 +81,29 @@ class GeyserLootTableTest {
               - {item: RAW_IRON, weight: 8, channel: mineral, amount: {min: 1, max: 3}}
               - {item: NOT_A_MATERIAL, weight: 100}
             """;
+
+    private static final String RECIPE_YAML = """
+            loot:
+              - {item: OBSIDIAN, weight: 5, from: [MAGMA_BLOCK, BASALT]}
+              - {item: KELP, weight: 5}
+            """;
+
+    private static final String VALUES_YAML = """
+            default: 1
+            use-level-addon: false
+            values:
+              DIAMOND: 45
+              RAW_IRON: 5
+              PRISMARINE_SHARD: 3
+            """;
+
+    /**
+     * @return worth lookup backed by a values file in a temporary data folder
+     */
+    private GeyserValues values() throws IOException {
+        Files.writeString(new File(dataFolder, "geyser-values.yml").toPath(), VALUES_YAML);
+        return new GeyserValues(addon);
+    }
 
     private GeyserLootTable load(String yaml) throws InvalidConfigurationException {
         YamlConfiguration config = new YamlConfiguration();
@@ -89,25 +138,62 @@ class GeyserLootTableTest {
         GeyserLootTable table = load(YAML);
         GeyserLootEntry gems = table.getLoot().get(1);
         assertEquals(2.0, table.effectiveWeight(gems, Map.of()));
-        // Each offering point adds +50% of the base weight
-        assertEquals(2.0 * (1 + 0.5 * 4), table.effectiveWeight(gems, Map.of("gems", 4)));
+        // An offering that was nothing but gems pulls its channel the hardest
+        assertEquals(2.0 * 4, table.effectiveWeight(gems, Map.of("gems", 4)));
+        // Half the worth in gems pulls half as hard
+        assertEquals(2.0 * 2.5, table.effectiveWeight(gems, Map.of("gems", 10, "mineral", 10)));
         // Bias on another channel does nothing
         assertEquals(2.0, table.effectiveWeight(gems, Map.of("mineral", 4)));
+    }
+
+    @Test
+    void testEffectiveWeightBiasIsShareNotSize() throws InvalidConfigurationException {
+        GeyserLootTable table = load(YAML);
+        GeyserLootEntry gems = table.getLoot().get(1);
+        // One diamond's worth of gems pulls as hard as a hoard of it - what
+        // matters is that the offering was all gems, not how big it was
+        assertEquals(table.effectiveWeight(gems, Map.of("gems", 45)),
+                table.effectiveWeight(gems, Map.of("gems", 4500)));
     }
 
     @Test
     void testRollHonorsBias() throws InvalidConfigurationException {
         GeyserLootTable table = load(YAML);
         Random random = new Random(42);
-        // Overwhelming gems bias means gems should dominate the rolls
+        // Gems are 2 of 20 base weight in this table; an all-gems offering
+        // quadruples that, so they should turn up far more often than 10%
         int gems = 0;
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 1000; i++) {
             GeyserLootEntry entry = table.roll(random, Map.of("gems", 1000));
             if ("gems".equals(entry.channel())) {
                 gems++;
             }
         }
-        assertTrue(gems > 90, "Expected gems to dominate but rolled only " + gems);
+        assertTrue(gems > 250, "Expected an all-gems offering to pull gems hard, but rolled only " + gems + "/1000");
+    }
+
+    @Test
+    void testEffectiveWeightCeilingBlocksRichRewards() throws InvalidConfigurationException, IOException {
+        GeyserLootTable table = load(YAML);
+        GeyserValues values = values();
+        GeyserLootEntry diamond = table.getLoot().get(1);
+        // Plenty of worth offered, but nothing rich enough to justify a diamond
+        assertEquals(0.0, table.effectiveWeight(diamond, new GeyserOffer(Map.of(), Set.of(), 500, 8), values));
+        assertTrue(table.effectiveWeight(diamond, new GeyserOffer(Map.of(), Set.of(), 500, 360), values) > 0);
+    }
+
+    @Test
+    void testTransmutationIgnoresTheCeiling() throws InvalidConfigurationException, IOException {
+        GeyserLootTable table = load(RECIPE_YAML);
+        GeyserValues values = values();
+        GeyserLootEntry obsidian = table.getLoot().get(0);
+        // Obsidian is not in the test values file, so it falls back to 1 - make
+        // the ceiling bite by asking about an entry with an explicit value
+        GeyserLootEntry rich = new GeyserLootEntry(Material.OBSIDIAN, null, 5, null, 1, 1, 500,
+                Set.of(Material.MAGMA_BLOCK));
+        GeyserOffer offer = new GeyserOffer(Map.of(), Set.of(Material.MAGMA_BLOCK), 1000, 8);
+        assertTrue(table.effectiveWeight(rich, offer, values) > 0, "A named transmutation must ignore the ceiling");
+        assertTrue(table.effectiveWeight(obsidian, offer, values) > 0);
     }
 
     @Test
@@ -116,6 +202,54 @@ class GeyserLootTableTest {
         Random random = new Random(42);
         for (int i = 0; i < 100; i++) {
             assertTrue(table.getLoot().contains(table.roll(random, Map.of())));
+        }
+    }
+
+    @Test
+    void testEffectiveWeightRecipeBoost() throws InvalidConfigurationException {
+        GeyserLootTable table = load(RECIPE_YAML);
+        GeyserLootEntry obsidian = table.getLoot().get(0);
+        // Nothing offered that transmutes into it
+        assertEquals(5.0, table.effectiveWeight(obsidian, GeyserOffer.of(Map.of()), null));
+        // Offering magma makes obsidian eight times as likely
+        GeyserOffer magma = new GeyserOffer(Map.of(), Set.of(Material.MAGMA_BLOCK), GeyserOffer.UNLIMITED);
+        assertEquals(40.0, table.effectiveWeight(obsidian, magma, null));
+    }
+
+    @Test
+    void testEffectiveWeightUnaffordableIsNeverRolled() throws InvalidConfigurationException, IOException {
+        GeyserLootTable table = load(YAML);
+        GeyserValues values = values();
+        GeyserLootEntry diamond = table.getLoot().get(1);
+        // A vent that owes 10 cannot pay out a diamond worth 45
+        assertEquals(0.0, table.effectiveWeight(diamond, new GeyserOffer(Map.of(), Set.of(), 10), values));
+        // One that owes 45 can, and is not damped because it is not a pittance
+        assertEquals(2.0, table.effectiveWeight(diamond, new GeyserOffer(Map.of(), Set.of(), 45), values));
+    }
+
+    @Test
+    void testEffectiveWeightPittanceIsDamped() throws InvalidConfigurationException, IOException {
+        GeyserLootTable table = load(YAML);
+        // Raw iron is worth 5 against a budget of 450 - the vent leans away from it
+        GeyserLootEntry iron = table.getLoot().get(2);
+        assertEquals(8.0 * 0.25, table.effectiveWeight(iron, new GeyserOffer(Map.of(), Set.of(), 450), values()));
+    }
+
+    @Test
+    void testRollReturnsNullWhenNothingIsAffordable() throws InvalidConfigurationException, IOException {
+        GeyserLootTable table = load(YAML);
+        // A budget of zero can buy nothing in this table
+        assertNull(table.roll(new Random(42), new GeyserOffer(Map.of(), Set.of(), 0), values()));
+    }
+
+    @Test
+    void testRollStaysWithinBudget() throws InvalidConfigurationException, IOException {
+        GeyserLootTable table = load(YAML);
+        GeyserValues values = values();
+        Random random = new Random(42);
+        for (int i = 0; i < 100; i++) {
+            GeyserLootEntry entry = table.roll(random, new GeyserOffer(Map.of(), Set.of(), 6), values);
+            assertTrue(values.unitValue(entry) <= 6, "Rolled " + entry.material() + " the vent cannot afford");
         }
     }
 

--- a/src/test/java/world/bentobox/acidisland/geysers/GeyserOfferingsTaskTest.java
+++ b/src/test/java/world/bentobox/acidisland/geysers/GeyserOfferingsTaskTest.java
@@ -1,11 +1,18 @@
 package world.bentobox.acidisland.geysers;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.util.UUID;
+
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Item;
+import org.bukkit.persistence.PersistentDataContainer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -81,6 +88,51 @@ class GeyserOfferingsTaskTest {
     void testOfferToVentWhenInert() {
         // An inert task must refuse offers without touching the item
         GeyserOfferingsTask task = new GeyserOfferingsTask(addon);
-        assertFalse(task.offerToVent(Mockito.mock(org.bukkit.entity.Item.class)));
+        assertFalse(task.offerToVent(thrownItem(UUID.randomUUID(), false)));
+    }
+
+    @Test
+    void testIsOfferingThrownByPlayer() {
+        assertTrue(GeyserOfferingsTask.isOffering(thrownItem(UUID.randomUUID(), false)));
+    }
+
+    @Test
+    void testIsOfferingIgnoresDeathDrops() {
+        // Death drops, block drops and mob drops have no thrower and must be left alone
+        assertFalse(GeyserOfferingsTask.isOffering(thrownItem(null, false)));
+    }
+
+    @Test
+    void testIsOfferingIgnoresRewards() {
+        assertFalse(GeyserOfferingsTask.isOffering(thrownItem(UUID.randomUUID(), true)));
+    }
+
+    @Test
+    void testDominantChannelOfNothing() {
+        assertNull(GeyserOfferingsTask.dominantChannel(new GeyserOfferingsTask.VentOfferings()));
+    }
+
+    @Test
+    void testDominantChannelIsTheMostFed() {
+        GeyserOfferingsTask.VentOfferings offerings = new GeyserOfferingsTask.VentOfferings();
+        offerings.bias.put("gems", 2);
+        offerings.bias.put("mineral", 7);
+        offerings.bias.put("forestry", 5);
+        assertEquals("mineral", GeyserOfferingsTask.dominantChannel(offerings));
+    }
+
+    /**
+     * @param thrower who threw the item, or null for a death or block drop
+     * @param reward true to tag the item as one the vent just spewed
+     * @return a mocked item entity
+     */
+    private Item thrownItem(UUID thrower, boolean reward) {
+        Item item = Mockito.mock(Item.class);
+        PersistentDataContainer pdc = Mockito.mock(PersistentDataContainer.class);
+        // Generic type erasure means the PDC key and type must be matched loosely
+        when(pdc.has(any(), any())).thenReturn(reward);
+        when(item.getPersistentDataContainer()).thenReturn(pdc);
+        when(item.getThrower()).thenReturn(thrower);
+        return item;
     }
 }

--- a/src/test/java/world/bentobox/acidisland/geysers/GeyserPayoutTest.java
+++ b/src/test/java/world/bentobox/acidisland/geysers/GeyserPayoutTest.java
@@ -1,0 +1,258 @@
+package world.bentobox.acidisland.geysers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import world.bentobox.acidisland.AcidIsland;
+import world.bentobox.acidisland.geysers.GeyserLootTable.Award;
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.managers.AddonsManager;
+
+/**
+ * The payout has to be a fair trade with the files AcidIsland actually ships,
+ * not just with a toy table: a diamond must come back in gems rather than in a
+ * heap of kelp, and a stack of cobble must not come back as a diamond.
+ * <p>
+ * SULFUR and CINNABAR do not exist on the 1.21 test classpath, so the shipped
+ * table loses those entries here - which only makes the trade harder to
+ * balance, not easier.
+ *
+ * @author tastybento
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class GeyserPayoutTest {
+
+    /** How many rewards a single eruption may spew, matching config.yml. */
+    private static final int MAX_REWARDS = 12;
+    /** How rich a single reward may be next to the richest item offered, matching config.yml. */
+    private static final int CEILING_MULTIPLIER = 8;
+
+    @Mock
+    private AcidIsland addon;
+    @Mock
+    private BentoBox plugin;
+    @Mock
+    private AddonsManager addonsManager;
+
+    @TempDir
+    File dataFolder;
+
+    private ServerMock server;
+    private MockedStatic<Bukkit> mockedBukkit;
+    private GeyserLootTable table;
+    private GeyserValues values;
+
+    @BeforeEach
+    void setUp() throws IOException, InvalidConfigurationException {
+        server = MockBukkit.mock();
+        mockedBukkit = Mockito.mockStatic(Bukkit.class, Mockito.RETURNS_DEEP_STUBS);
+        mockedBukkit.when(Bukkit::getMinecraftVersion).thenReturn("1.21.11");
+        mockedBukkit.when(Bukkit::getServer).thenReturn(server);
+        when(addon.getDataFolder()).thenReturn(dataFolder);
+        when(addon.getPlugin()).thenReturn(plugin);
+        when(plugin.getAddonsManager()).thenReturn(addonsManager);
+        when(addonsManager.getAddonByName("Level")).thenReturn(Optional.empty());
+        Files.writeString(new File(dataFolder, "geyser-values.yml").toPath(), shipped("geyser-values.yml"));
+        values = new GeyserValues(addon);
+        YamlConfiguration config = new YamlConfiguration();
+        config.loadFromString(shipped("geyser-loot.yml"));
+        table = GeyserLootTable.parse(config);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedBukkit.closeOnDemand();
+        MockBukkit.unmock();
+    }
+
+    /**
+     * @param name resource in src/main/resources
+     * @return its contents
+     */
+    private String shipped(String name) throws IOException {
+        try (InputStream in = GeyserPayoutTest.class.getClassLoader().getResourceAsStream(name)) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * Build the offer a vent would make of an offering, the way the task does:
+     * worth-weighted channel bias, total worth as the budget, and a ceiling off
+     * the richest single item.
+     *
+     * @param offering material to amount thrown in
+     * @return the offer
+     */
+    private GeyserOffer offer(Map<Material, Integer> offering) {
+        int budget = 0;
+        int top = 0;
+        Map<String, Integer> bias = new HashMap<>();
+        for (Map.Entry<Material, Integer> e : offering.entrySet()) {
+            int worth = values.getValue(e.getKey()) * e.getValue();
+            budget += worth;
+            top = Math.max(top, values.getValue(e.getKey()));
+            String channel = GeyserLootTable.categorize(e.getKey());
+            if (channel != null) {
+                bias.merge(channel, worth, Integer::sum);
+            }
+        }
+        return new GeyserOffer(bias, offering.keySet(), budget, Math.max(1, top * CEILING_MULTIPLIER));
+    }
+
+    /**
+     * @param offer what the vent was fed
+     * @return total worth of one payout
+     */
+    private int payoutValue(GeyserOffer offer, Random random) {
+        int total = 0;
+        for (Award award : table.plan(random, offer, values, MAX_REWARDS)) {
+            total += values.unitValue(award.entry()) * award.amount();
+        }
+        return total;
+    }
+
+    @Test
+    void testShippedFilesLoad() {
+        assertFalse(table.isEmpty());
+        assertEquals(45, values.getValue(Material.DIAMOND));
+    }
+
+    @Test
+    void testDiamondIsAFairTrade() {
+        Random random = new Random(42);
+        GeyserOffer diamond = offer(Map.of(Material.DIAMOND, 1));
+        for (int i = 0; i < 200; i++) {
+            int paid = payoutValue(diamond, random);
+            // Never more than was offered, and never a derisory handful
+            assertTrue(paid <= diamond.budget(), "Paid out " + paid + " for a diamond worth " + diamond.budget());
+            assertTrue(paid >= diamond.budget() / 2, "Paid out only " + paid + " for a diamond");
+        }
+    }
+
+    @Test
+    void testDiamondIsAnsweredInGems() {
+        Random random = new Random(42);
+        GeyserOffer diamond = offer(Map.of(Material.DIAMOND, 1));
+        int gems = 0;
+        for (int i = 0; i < 200; i++) {
+            if (table.plan(random, diamond, values, MAX_REWARDS).stream()
+                    .anyMatch(a -> "gems".equals(a.entry().channel()))) {
+                gems++;
+            }
+        }
+        assertTrue(gems > 100, "A diamond should mostly come back in gems, but only " + gems + " of 200 payouts did");
+    }
+
+    @Test
+    void testCobbleCannotBuyGems() {
+        Random random = new Random(42);
+        // A cobble generator is infinite, so a stack of it must not print gems
+        GeyserOffer cobble = offer(Map.of(Material.COBBLESTONE, 64));
+        for (int i = 0; i < 200; i++) {
+            for (Award award : table.plan(random, cobble, values, MAX_REWARDS)) {
+                assertTrue(values.unitValue(award.entry()) <= cobble.ceiling(),
+                        "A stack of cobble bought a " + award.entry().material());
+            }
+        }
+    }
+
+    @Test
+    void testPayoutNeverExceedsTheOffering() {
+        Random random = new Random(7);
+        for (int budget = 1; budget <= 500; budget += 7) {
+            GeyserOffer any = new GeyserOffer(Map.of(), Set.of(), budget);
+            assertTrue(payoutValue(any, random) <= budget, "Overpaid on a budget of " + budget);
+        }
+    }
+
+    @Test
+    void testBigOfferingIsNotWasted() {
+        Random random = new Random(7);
+        // A diamond chestplate is worth far more than 12 average rewards, so the
+        // vent has to scale amounts up rather than pocket the difference
+        GeyserOffer gear = offer(Map.of(Material.DIAMOND_CHESTPLATE, 1));
+        for (int i = 0; i < 100; i++) {
+            int paid = payoutValue(gear, random);
+            assertTrue(paid >= gear.budget() * 0.75, "Paid out only " + paid + " of " + gear.budget());
+        }
+    }
+
+    @Test
+    void testTinyOfferingStillPaysSomething() {
+        Random random = new Random(7);
+        // One kelp is worth 1 - the vent must still find something to give back
+        assertFalse(table.plan(random, offer(Map.of(Material.KELP, 1)), values, MAX_REWARDS).isEmpty());
+    }
+
+    @Test
+    void testMagmaTransmutesIntoObsidian() {
+        Random random = new Random(42);
+        GeyserOffer magma = offer(Map.of(Material.MAGMA_BLOCK, 16));
+        int obsidian = 0;
+        for (int i = 0; i < 100; i++) {
+            List<Award> awards = table.plan(random, magma, values, MAX_REWARDS);
+            if (awards.stream().anyMatch(a -> a.entry().material() == Material.OBSIDIAN)) {
+                obsidian++;
+            }
+        }
+        assertTrue(obsidian > 50, "Magma should reliably make obsidian, but only " + obsidian + " of 100 payouts did");
+    }
+
+    @Test
+    void testBonesAndGunpowderTransmuteIntoRecords() {
+        Random random = new Random(42);
+        // A hopper full of skeleton and creeper drops, offered to the vent.
+        // A record is worth 40 against a ceiling of 32, so only the written-down
+        // transmutation can produce one - which is the point of from:
+        GeyserOffer drops = offer(Map.of(Material.BONE, 32, Material.GUNPOWDER, 16));
+        int discs = 0;
+        for (int i = 0; i < 100; i++) {
+            List<Award> awards = table.plan(random, drops, values, MAX_REWARDS);
+            if (awards.stream().anyMatch(a -> a.entry().material().name().startsWith("MUSIC_DISC"))) {
+                discs++;
+            }
+        }
+        assertTrue(discs > 20, "Bones and gunpowder should sometimes make a record, but only " + discs + " of 100 did");
+    }
+
+    @Test
+    void testUnmatchedPayoutIgnoresWorth() {
+        // With match-value off the vent rolls once per item, whatever it is worth
+        Random random = new Random(42);
+        List<Award> awards = table.plan(random, GeyserOffer.of(Map.of()), null, 5);
+        assertEquals(5, awards.size());
+    }
+}

--- a/src/test/java/world/bentobox/acidisland/geysers/GeyserValuesTest.java
+++ b/src/test/java/world/bentobox/acidisland/geysers/GeyserValuesTest.java
@@ -1,0 +1,146 @@
+package world.bentobox.acidisland.geysers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Optional;
+import java.util.Set;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import world.bentobox.acidisland.AcidIsland;
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.addons.Addon;
+import world.bentobox.bentobox.managers.AddonsManager;
+
+/**
+ * @author tastybento
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class GeyserValuesTest {
+
+    private static final String YAML = """
+            default: 2
+            use-level-addon: false
+            values:
+              DIAMOND: 45
+              EMERALD: 15
+              COBBLESTONE: 1
+              NOT_A_MATERIAL: 99
+              NEGATIVE: -5
+            """;
+
+    @Mock
+    private AcidIsland addon;
+    @Mock
+    private BentoBox plugin;
+    @Mock
+    private AddonsManager addonsManager;
+
+    @TempDir
+    File dataFolder;
+
+    private ServerMock server;
+    private MockedStatic<Bukkit> mockedBukkit;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        mockedBukkit = Mockito.mockStatic(Bukkit.class, Mockito.RETURNS_DEEP_STUBS);
+        mockedBukkit.when(Bukkit::getMinecraftVersion).thenReturn("1.21.11");
+        mockedBukkit.when(Bukkit::getServer).thenReturn(server);
+        when(addon.getDataFolder()).thenReturn(dataFolder);
+        when(addon.getPlugin()).thenReturn(plugin);
+        when(plugin.getAddonsManager()).thenReturn(addonsManager);
+        when(addonsManager.getAddonByName("Level")).thenReturn(Optional.empty());
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedBukkit.closeOnDemand();
+        MockBukkit.unmock();
+    }
+
+    private GeyserValues load(String yaml) throws IOException {
+        Files.writeString(new File(dataFolder, "geyser-values.yml").toPath(), yaml);
+        return new GeyserValues(addon);
+    }
+
+    @Test
+    void testConfiguredValueWins() throws IOException {
+        assertEquals(45, load(YAML).getValue(Material.DIAMOND));
+    }
+
+    @Test
+    void testUnlistedMaterialFallsBackToDefault() throws IOException {
+        GeyserValues values = load(YAML);
+        assertEquals(2, values.getDefaultValue());
+        assertEquals(2, values.getValue(Material.PUMPKIN));
+    }
+
+    @Test
+    void testNegativeValuesAreFloored() throws IOException {
+        // A negative worth would let a vent pay out for free
+        assertEquals(0, load("values:\n  DIAMOND: -5\n").getValue(Material.DIAMOND));
+    }
+
+    @Test
+    void testMissingFileUsesDefaults() {
+        // No file on disk and nothing to save from the jar in a test - still usable
+        GeyserValues values = new GeyserValues(addon);
+        assertEquals(1, values.getDefaultValue());
+        assertEquals(1, values.getValue(Material.DIAMOND));
+    }
+
+    @Test
+    void testBrokenLevelHookFallsBackQuietly() throws IOException {
+        // An addon named Level that is not the Level we know: the hook must
+        // fail over to the values file rather than take the vent down
+        when(addonsManager.getAddonByName("Level")).thenReturn(Optional.of(Mockito.mock(Addon.class)));
+        GeyserValues values = load("default: 3\nvalues:\n  DIAMOND: 45\n");
+        assertEquals(45, values.getValue(Material.DIAMOND));
+        assertEquals(3, values.getValue(Material.PUMPKIN));
+    }
+
+    @Test
+    void testStackValueIsPerItem() throws IOException {
+        assertEquals(45, load(YAML).getValue(new ItemStack(Material.EMERALD, 3)));
+    }
+
+    @Test
+    void testEntryValueOverridesMaterial() throws IOException {
+        GeyserLootEntry entry = new GeyserLootEntry(Material.DIAMOND, null, 1, null, 1, 1, 7, Set.of());
+        assertEquals(7, load(YAML).unitValue(entry));
+    }
+
+    @Test
+    void testEntryWithoutValueUsesMaterial() throws IOException {
+        GeyserLootEntry entry = new GeyserLootEntry(Material.DIAMOND, null, 1, null, 1, 1);
+        assertEquals(45, load(YAML).unitValue(entry));
+    }
+
+    @Test
+    void testCommandEntryIsFreeUnlessValued() throws IOException {
+        GeyserLootEntry entry = new GeyserLootEntry(null, "say hi", 1, null, 1, 1);
+        assertEquals(0, load(YAML).unitValue(entry));
+    }
+}


### PR DESCRIPTION
Ships the geyser offering economy that was meant to be in 2.1.0.

2.1.0 released the geyser mechanic as one reward roll per item, biased by channel — a vent was a slot machine where a stack of cobble and a diamond bought the same spin. This makes it a trade:

- **Worth matching** — a vent adds up what an offering was worth (`geyser-values.yml`, falling back to the Level addon's block values) and keeps rolling rewards it can afford until that worth is spent.
- **Worth-weighted channel bias** — one diamond steers the table as firmly as the stack of cobble it is worth.
- **Named transmutations** (`from:`) — magma into obsidian, iron into gold, bones and gunpowder into records. The one route past the reward ceiling.
- **Reward ceiling** — stops a cobble generator becoming a gem printer.
- **Item drift and provoked eruptions** — throws need not be accurate, and the payout lands while the player is still watching.
- **Player messages** — the mechanic was silent in 2.1.0; all 24 locales now carry the geyser strings.

New config: `match-value`, `exchange-rate`, `reward-ceiling`, `erupt-on-offering`. New file: `geyser-values.yml`.

452 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rw3Vwjf35ZaZyPhp9Yo29k